### PR TITLE
fix(sw): 文章导航不再错误命中首页 HTML 缓存

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // 与 ?v=VERSION 的 cache-busting 协同：CACHE_NAME 用 release VERSION 区分批次
 // ============================================================================
 
-const SW_VERSION = '20260512184000';
+const SW_VERSION = '20260513120000';
 const STATIC_CACHE = `static-${SW_VERSION}`;
 const PAGE_CACHE = `pages-${SW_VERSION}`;
 const RUNTIME_CACHE = `runtime-${SW_VERSION}`;
@@ -120,8 +120,13 @@ async function matchHtmlShell(request) {
   const name = path.split('/').pop() || 'index.html';
   const shell = name === '' ? 'index.html' : name;
 
-  // post.html?slug=xxx / tags.html#xxx 这类页面壳相同，query 不应该影响命中。
-  for (const key of [shell, './' + shell, 'index.html', './']) {
+  // post.html?slug=xxx / tags.html#xxx 等：query/hash 不同仍共用同一 HTML 壳，只匹配该壳。
+  // 切勿对 post.html 等回落到 index.html，否则微信等环境下会「点文章却看到首页」。
+  const keys = [shell, './' + shell];
+  if (shell === 'index.html') {
+    keys.push('./', 'index.html');
+  }
+  for (const key of keys) {
     const hit = await caches.match(key);
     if (hit) return hit;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

在微信内置浏览器等环境下，从首页点进 `post.html?slug=…` 时，Service Worker 的 `matchHtmlShell` 在找不到 `post.html` 壳缓存后会继续尝试 `index.html` / `./`，从而把**首页 HTML** 当作导航响应返回，表现为「点的文章却仍是首页」；多次点击会在历史栈里留下多条记录，返回时后退行为异常。

## 修改

- `matchHtmlShell` 仅对站首页（`shell === 'index.html'`）保留 `./` 与 `index.html` 的别名命中；`post.html`、`tags.html` 等只匹配自身壳，不再回落到首页。
- 将 `SW_VERSION`  bump 到 `20260513120000`，使旧 `pages-*` / `static-*` 缓存在激活时被清理，客户端尽快拿到新逻辑。

## 部署后说明

已访问过旧版的用户需**再打开一次站点**（或关开微信内页面）让新 SW 安装并 `skipWaiting` 后生效；若站点有「刷新以更新」提示可一并使用。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

