### PR TITLE
fix(pageviews): 首页站点计数因 hero+footer 重复各 +1

### DIFF
--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -347,7 +347,8 @@ function applyFilter(posts, tab, q, tag) {
 }
 
 (async function init() {
-  initSite({ active: './' });
+  // 避免 hero 与 footer 各有一份站点计数（saobby 会加载两张图 +2；不蒜子会重复容器）
+  initSite({ active: './', skipDuplicateSitePv: true });
   setMeta({ title: '', description: CONFIG.site.description, type: 'website' });
   setJsonLd({
     '@context': 'https://schema.org',

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -212,7 +212,7 @@ function navHtml(active) {
   `;
 }
 
-function footerHtml() {
+function footerHtml({ omitSitePv = false } = {}) {
   const social = CONFIG.site.social || {};
   const links = Object.entries(social)
     .filter(([, v]) => v)
@@ -221,7 +221,9 @@ function footerHtml() {
       const href = k === 'email' ? `mailto:${v}` : v;
       return `<a class="social-link" href="${escapeHtml(href)}" target="_blank" rel="noopener" title="${escapeHtml(k)}">${icon}</a>`;
     }).join('');
-  const pvHtml = (CONFIG.pageviews || {}).showFooterStats !== false ? bszSiteStatsHtml({ compact: true }) : '';
+  const pvCfg = CONFIG.pageviews || {};
+  const wantFooterPv = pvCfg.showFooterStats !== false && !omitSitePv;
+  const pvHtml = wantFooterPv ? bszSiteStatsHtml({ compact: true }) : '';
   const pv = pvHtml ? `<div class="footer-stats">${pvHtml}</div>` : '';
   return `
     <footer class="footer">
@@ -468,13 +470,15 @@ function injectAnalytics() {
   });
 }
 
-export function initSite({ active = '' } = {}) {
+export function initSite({ active = '', skipDuplicateSitePv = false } = {}) {
   initTheme();
   applyFavicon();
   const navHost = $('#site-nav');
   if (navHost) navHost.innerHTML = navHtml(active);
   const footerHost = $('#site-footer');
-  if (footerHost) footerHost.innerHTML = footerHtml();
+  const pvCfg = CONFIG.pageviews || {};
+  const omitFooterSitePv = skipDuplicateSitePv && pvCfg.showHomeStats !== false;
+  if (footerHost) footerHost.innerHTML = footerHtml({ omitSitePv: omitFooterSitePv });
   const overlayHost = $('#site-overlays');
   if (overlayHost) overlayHost.innerHTML = searchOverlayHtml();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 原因

首页先通过 `initSite` 在页脚插入站点访问计数，随后 `renderHero` 又在 hero 区插入同一份站点计数。

- **saobby**：每个占位各插入一张计数图，浏览器各请求一次计数 URL → 每次刷新 **+2**。
- **不蒜子**：两套 `busuanzi_container_site_*` 容器（且存在重复 `id`），脚本也可能对同一页统计两次。

## 修改

- `initSite` 增加可选参数 `skipDuplicateSitePv`（仅首页传入）。
- 当「首页会展示 hero 统计」且 `showHomeStats` 未关闭时，页脚不再输出站点级计数，只保留 hero 里那一套；若用户在设置里关闭首页 hero 统计，页脚仍会照常显示（避免没有计数可看）。

草稿 PR 便于你在合并前确认页脚是否仍希望保留纯展示（当前为去掉重复计数，页脚该块为空但布局不受影响）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

