### PR TITLE
refactor(pageviews): 站点 Saobby + 文章 Vercount，移除不蒜子与 PV API

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -295,65 +295,12 @@ async function renderDashboardStats(posts) {
       <div class="dashboard-card"><div class="dashboard-num">${recent30}</div><div class="dashboard-label">近 30 天</div></div>
     </div>
     <div class="dashboard-pv" id="dashboardPv">
-      <div class="dashboard-pv-title">阅读量 Top 10 <span class="dashboard-pv-hint">数据来自 Page Views API（每次访问加 1）</span></div>
+      <div class="dashboard-pv-title">阅读数据</div>
       <div class="dashboard-pv-list" id="dashboardPvList">
-        <div class="dashboard-pv-empty">读取中…</div>
+        <div class="dashboard-pv-empty">文章阅读量由 <a href="https://vercount.one" target="_blank" rel="noopener">Vercount</a> 按页面 URL 统计，请到 Vercount 控制台查看；站点总访问请查看 Saobby 控制面板或「访问数据」页。</div>
       </div>
     </div>
   `;
-
-  // 拉每篇文章的 PV，按降序展示前 10
-  if ((CONFIG.pageviews || {}).articleProvider !== 'page-views-api') {
-    const pvList = document.getElementById('dashboardPvList');
-    if (pvList) pvList.innerHTML = '<div class="dashboard-pv-empty">站点未启用 Page Views API（在「站点设置 → 访问计数」选择该 provider 即可）</div>';
-    return;
-  }
-  await loadPvTop(published.slice(0, 200));
-}
-
-async function loadPvTop(posts) {
-  const PAGE_VIEWS_API = 'https://page-views-api.ratneshc.com/api/v1';
-  function siteKey() {
-    try {
-      const u = new URL(CONFIG.site.url || (location.origin + (location.pathname.replace(/\/admin\/.*/, '') || '/')));
-      return (u.host + u.pathname).replace(/\/+$/, '').replace(/\//g, '__') || u.host;
-    } catch {
-      return 'gitblog';
-    }
-  }
-  const key = siteKey();
-  const limit = 8; // 并发上限
-  const results = [];
-  let cursor = 0;
-  async function worker() {
-    while (cursor < posts.length) {
-      const i = cursor++;
-      const p = posts[i];
-      try {
-        const r = await fetch(`${PAGE_VIEWS_API}/${encodeURIComponent(key)}/${encodeURIComponent('post:' + p.slug)}/views`);
-        if (r.ok) {
-          const j = await r.json();
-          results.push({ p, views: Number(j.views || j.count || 0) });
-        }
-      } catch {}
-    }
-  }
-  await Promise.all(Array.from({ length: limit }, worker));
-  results.sort((a, b) => b.views - a.views);
-  const top = results.slice(0, 10);
-  const list = document.getElementById('dashboardPvList');
-  if (!list) return;
-  if (!top.length || !top.some(x => x.views > 0)) {
-    list.innerHTML = '<div class="dashboard-pv-empty">还没有访问数据 — 等读者来访问吧</div>';
-    return;
-  }
-  list.innerHTML = top.map((x, i) => `
-    <a class="dashboard-pv-row" href="../post.html?slug=${encodeURIComponent(x.p.slug)}" target="_blank">
-      <span class="dashboard-pv-rank">#${i + 1}</span>
-      <span class="dashboard-pv-title">${escapeHtml(x.p.title || x.p.slug)}</span>
-      <span class="dashboard-pv-count">${x.views}</span>
-    </a>
-  `).join('');
 }
 
 (async function init() {

--- a/assets/js/analytics-admin.js
+++ b/assets/js/analytics-admin.js
@@ -1,14 +1,11 @@
 // ============================================================================
-// 后台「访问数据」：把已配置的 saobby 计数器控制面板用 iframe 嵌入
-//   - 站点级 / 文章页 / 自建额外计数器各占一个 tab
-//   - 每篇带 frontmatter.counter 的文章也单独一个 tab
-//   - 没有配置 saobby 时，引导用户去站点设置 / saobby.com
-//   - 兼容 saobby 控制面板若禁止被 iframe 嵌入的情况：错误时给出"在新页面打开"按钮
+// 后台「访问数据」：嵌入已配置的 Saobby 控制面板
+//   - 站点级 + 额外计数器；单篇阅读请在 vercount.one 查看（前台用 Vercount）
 // ============================================================================
 
 import { CONFIG } from './config.js';
-import { fetchIndexPublic, readIndex } from './api.js';
-import { mountAdminShell, escapeHtml, showToast } from './admin-shell.js';
+import { mountAdminShell, escapeHtml } from './admin-shell.js';
+import { isSaobbyOn } from './pageviews.js';
 
 const $ = sel => document.querySelector(sel);
 
@@ -16,80 +13,40 @@ function pvCfg() {
   return CONFIG.pageviews || {};
 }
 
-function provider() {
-  const cfg = pvCfg();
-  if (!cfg.enabled) return 'none';
-  return cfg.provider || 'busuanzi';
-}
-
 function saobbyCfg() {
   return pvCfg().saobby || {};
 }
 
-function listCounters(posts = []) {
+function listCounters() {
+  const cfg = pvCfg();
+  if (cfg.enabled === false) return [];
   const sb = saobbyCfg();
   const items = [];
   const site = sb.site || {};
   if (site.img || site.dashboard) {
     items.push({ id: 'site', name: '站点总计数器', img: site.img, dashboard: site.dashboard, kind: 'site' });
   }
-  const article = sb.article || {};
-  if (article.img || article.dashboard) {
-    items.push({ id: 'article', name: '文章页（全站共用）', img: article.img, dashboard: article.dashboard, kind: 'article' });
-  }
   (sb.extra || []).forEach((it, i) => {
     if (!it) return;
     if (it.img || it.dashboard) {
-      items.push({ id: `extra-${i}`, name: it.name || `自建计数器 ${i + 1}`, img: it.img, dashboard: it.dashboard, kind: 'extra' });
+      items.push({ id: `extra-${i}`, name: it.name || `额外计数器 ${i + 1}`, img: it.img, dashboard: it.dashboard, kind: 'extra' });
     }
-  });
-  // 每篇带 frontmatter.counter 的文章
-  posts.forEach(p => {
-    if (!p || !p.counter) return;
-    const c = p.counter;
-    if (!c.img && !c.dashboard) return;
-    items.push({
-      id: `post-${p.slug}`,
-      name: `文章：${p.title || p.slug}`,
-      img: c.img,
-      dashboard: c.dashboard,
-      kind: 'post',
-      slug: p.slug,
-    });
   });
   return items;
 }
 
-async function loadPosts() {
-  try {
-    const idx = await readIndex().catch(() => null);
-    if (idx && idx.data && Array.isArray(idx.data.posts)) return idx.data.posts;
-  } catch {}
-  try {
-    const idx = await fetchIndexPublic();
-    if (idx && Array.isArray(idx.posts)) return idx.posts;
-  } catch {}
-  return [];
-}
-
-function articlesWithoutCounter(posts) {
-  return posts.filter(p => !p.draft && !p.page && !(p.counter && (p.counter.img || p.counter.dashboard)));
-}
-
 function emptyHtml() {
-  const isSaobby = provider() === 'saobby';
   return `
     <section class="admin-empty-card">
-      <h2>暂时没有可展示的访问数据</h2>
-      ${isSaobby
-        ? '<p>当前 provider 是 <b>saobby</b>，但还没有配置任何计数器。</p>'
-        : `<p>当前 provider 是 <b>${escapeHtml(provider())}</b>。本页面仅支持嵌入 <b>saobby</b> 的控制面板。</p>`
+      <h2>暂时没有可嵌入的 Saobby 控制面板</h2>
+      ${isSaobbyOn()
+        ? '<p>已启用计数，但尚未配置「站点」或「额外」计数器的控制面板 URL。</p>'
+        : '<p>尚未在站点设置中配置 Saobby 站点计数图片 URL。</p>'
       }
       <ol style="margin:14px 0 0 18px;color:var(--text-secondary);line-height:1.9;">
-        <li>到 <a href="https://www.saobby.com/create_webcounter" target="_blank" rel="noopener">saobby.com / 创建网页计数器</a> 创建一个或多个计数器（默认设置即可）。</li>
-        <li>每个计数器都会得到一张 <b>计数图片 URL</b> 和一个 <b>控制面板 URL</b>（含 key）。</li>
-        <li>回到本站「站点设置 → 访问计数」，把图片 URL 和控制面板 URL 填进对应字段，并将 provider 切到 <code>saobby</code>。</li>
-        <li>保存后回到本页，即可看到嵌入的控制面板。</li>
+        <li>到 <a href="https://www.saobby.com/create_webcounter" target="_blank" rel="noopener">saobby.com</a> 创建站点计数器。</li>
+        <li>在「站点设置」里填写图片 URL 与控制面板 URL 并保存。</li>
+        <li>单篇阅读量请在 <a href="https://vercount.one" target="_blank" rel="noopener">vercount.one</a> 查看（本站文章页使用 Vercount）。</li>
       </ol>
       <p style="margin-top:18px"><a class="btn btn-primary" href="settings.html">前往站点设置 →</a></p>
     </section>
@@ -97,23 +54,14 @@ function emptyHtml() {
 }
 
 function counterTabsHtml(items) {
-  // 把文章计数器折叠到一个二级 select，避免几十篇文章把 tab 撑爆
-  const pinned = items.filter(it => it.kind !== 'post');
-  const posts = items.filter(it => it.kind === 'post');
   const firstId = items[0] ? items[0].id : '';
   return `
     <div class="analytics-tabs" role="tablist">
-      ${pinned.map(it => `
+      ${items.map(it => `
         <button type="button" class="analytics-tab${it.id === firstId ? ' active' : ''}" data-tab-id="${escapeHtml(it.id)}" role="tab">
           ${escapeHtml(it.name)}
         </button>
       `).join('')}
-      ${posts.length ? `
-        <select class="analytics-post-select" id="analyticsPostSelect">
-          <option value="">— 文章独立计数器（${posts.length}）—</option>
-          ${posts.map(p => `<option value="${escapeHtml(p.id)}">${escapeHtml(p.name)}</option>`).join('')}
-        </select>
-      ` : ''}
     </div>
   `;
 }
@@ -155,7 +103,7 @@ function counterPanelHtml(item, active) {
 function topActions() {
   return `
     <a class="btn btn-secondary" href="https://www.saobby.com/create_webcounter" target="_blank" rel="noopener">+ 新建 saobby 计数器</a>
-    <a class="btn btn-primary" href="settings.html#pv">配置计数器</a>
+    <a class="btn btn-primary" href="settings.html">站点设置</a>
   `;
 }
 
@@ -168,15 +116,6 @@ function bindTabs() {
   document.querySelectorAll('.analytics-tab').forEach(tab => {
     tab.addEventListener('click', () => activatePanel(tab.dataset.tabId));
   });
-  const sel = document.getElementById('analyticsPostSelect');
-  if (sel) {
-    sel.addEventListener('change', () => {
-      const id = sel.value;
-      if (!id) return;
-      activatePanel(id);
-      document.querySelectorAll('.analytics-tab').forEach(t => t.classList.remove('active'));
-    });
-  }
 }
 
 function watchIframeLoadFailures() {
@@ -196,33 +135,18 @@ function watchIframeLoadFailures() {
   });
 }
 
-function postsWithoutCounterHtml(posts) {
-  const missing = articlesWithoutCounter(posts);
-  if (!missing.length) return '';
+function vercountHintHtml() {
   return `
-    <details class="analytics-missing">
-      <summary>${missing.length} 篇文章还没有独立计数器（点击展开）</summary>
-      <p class="settings-hint" style="margin:6px 0 10px 0">
-        在文章编辑器里点「为本文创建计数器…」即可补上。每篇创建后回到本页能看到对应控制面板。
-      </p>
-      <ul class="analytics-missing-list">
-        ${missing.slice(0, 50).map(p => `
-          <li>
-            <a href="editor.html?slug=${encodeURIComponent(p.slug)}">${escapeHtml(p.title || p.slug)}</a>
-            <span class="analytics-missing-meta">${escapeHtml(String(p.date || '').slice(0, 10))}</span>
-          </li>
-        `).join('')}
-      </ul>
-      ${missing.length > 50 ? `<p class="settings-hint">…共 ${missing.length} 篇，先列前 50 篇</p>` : ''}
-    </details>
+    <p class="settings-help" style="margin:12px 0 0">
+      单篇阅读量由 <a href="https://vercount.one" target="_blank" rel="noopener">Vercount</a> 按页面 URL 统计，请到其控制台查看。
+    </p>
   `;
 }
 
 (async function init() {
   const ctx = await mountAdminShell({ active: 'analytics', title: '访问数据', actions: topActions() });
   if (!ctx) return;
-  const posts = await loadPosts();
-  const items = listCounters(posts);
+  const items = listCounters();
   if (!items.length) {
     ctx.content.innerHTML = emptyHtml();
     return;
@@ -230,10 +154,10 @@ function postsWithoutCounterHtml(posts) {
   ctx.content.innerHTML = `
     <div class="analytics-shell">
       <p class="settings-help" style="margin:0 0 12px 0">
-        以下控制面板由 <a href="https://www.saobby.com" target="_blank" rel="noopener">saobby.com</a> 提供。每张图片即一个独立计数器，加载页面就会 +1；首屏数字延迟一两秒属于正常现象。
+        以下控制面板由 <a href="https://www.saobby.com" target="_blank" rel="noopener">saobby.com</a> 提供。每张图片即一个独立计数器；首屏数字延迟一两秒属于正常现象。
       </p>
       ${counterTabsHtml(items)}
-      ${postsWithoutCounterHtml(posts)}
+      ${vercountHintHtml()}
       <div class="analytics-panels">
         ${items.map((it, i) => counterPanelHtml(it, i === 0)).join('')}
       </div>

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -74,24 +74,20 @@ export const CONFIG = {
   },
   pageviews: {
     enabled: true,
-    provider: "saobby",
-    articleProvider: "page-views-api",
     showHomeStats: true,
     showPostViews: true,
     showFooterStats: true,
-    showListPostViews: true,
     saobby: {
       site: {
         img: "https://w.saobby.com/w/ivywp8ie",
         dashboard: "https://www.saobby.com/webcounter_dashboard?access_token=59nv7dkv",
         label: "人来过"
       },
-      article: {
-        img: "https://w.saobby.com/w/qabb4byw",
-        dashboard: "https://www.saobby.com/webcounter_dashboard?access_token=xxnc4lgt",
-        label: "阅读"
-      },
       extra: []
+    },
+    vercount: {
+      scriptSrc: "",
+      label: "阅读"
     }
   },
   auth: {

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -192,11 +192,6 @@ function setEditorTags(tags) {
 }
 
 // ---------- 文章独立计数器（saobby 半自动） ----------
-function isSaobbyProviderOn() {
-  const cfg = CONFIG.pageviews || {};
-  return cfg.enabled !== false && cfg.provider === 'saobby';
-}
-
 function setEditorCounter(counter) {
   state.counter = {
     img: String((counter && counter.img) || '').trim(),
@@ -208,26 +203,8 @@ function setEditorCounter(counter) {
 function renderEditorCounter() {
   const field = $('#counterField');
   if (!field) return;
-  if (!isSaobbyProviderOn()) {
-    field.hidden = true;
-    return;
-  }
-  field.hidden = false;
-  const summary = $('#counterSummary');
-  const clearBtn = $('#counterClearBtn');
-  const c = state.counter || {};
-  const has = !!(c.img || c.dashboard);
-  if (clearBtn) clearBtn.hidden = !has;
-  if (!summary) return;
-  if (!has) {
-    summary.innerHTML = '<span class="editor-counter-empty">本文还没有配置独立计数器。读者将看到「站点设置 → 文章页计数器」里设的全站共用计数器。</span>';
-    return;
-  }
-  summary.innerHTML = `
-    ${c.img ? `<div class="editor-counter-line"><span>图片</span> <a href="${escapeHtml(c.img)}" target="_blank" rel="noopener">${escapeHtml(c.img)}</a></div>` : ''}
-    ${c.dashboard ? `<div class="editor-counter-line"><span>控制面板</span> <a href="${escapeHtml(c.dashboard)}" target="_blank" rel="noopener">${escapeHtml(c.dashboard)}</a></div>` : ''}
-    ${c.img ? `<div class="editor-counter-line"><span>预览</span> <img src="${escapeHtml(c.img)}" alt="counter" referrerpolicy="no-referrer-when-downgrade" class="editor-counter-img"></div>` : ''}
-  `;
+  // 文章阅读数由 Vercount 按页面 URL 统计，编辑器不再配置 per-post 计数器
+  field.hidden = true;
 }
 
 function buildSaobbyCreateUrl() {

--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -5,8 +5,7 @@
 import { CONFIG } from './config.js';
 import { fetchIndexPublic } from './api.js';
 import { initSite, escapeHtml, fmtDate, timeAgo, tagHtml, bindLazyImages, LAZY_PLACEHOLDER } from './site.js';
-// 注：列表逐篇阅读数在 saobby provider 下会自动返回空，不影响渲染
-import { initPageviews, bszSiteStatsHtml, articleListPvHtml, renderArticleListViews } from './pageviews.js';
+import { initPageviews, bszSiteStatsHtml } from './pageviews.js';
 import { setMeta, setJsonLd } from './seo.js';
 
 const $ = sel => document.querySelector(sel);
@@ -237,7 +236,6 @@ function postItemHtml(p, author, avatar) {
         <p class="post-summary">${escapeHtml(p.summary || '')}</p>
         <div class="post-meta">
           ${(p.tags || []).slice(0, 3).map(t => tagHtml(t)).join('')}
-          ${articleListPvHtml(p.slug)}
         </div>
       </a>
       ${p.cover ? `<a href="post.html?slug=${encodeURIComponent(p.slug)}" class="post-thumbnail"><img src="${LAZY_PLACEHOLDER}" data-src="${escapeHtml(publicImageUrl(p.thumbnail || p.cover))}" alt="${escapeHtml(p.title || '')}" loading="lazy" decoding="async" fetchpriority="low"></a>` : ''}
@@ -273,7 +271,6 @@ function renderList(posts) {
       : `<li class="load-more-end">已经到底啦 · 共 ${posts.length} 篇</li>`);
   // 列表缩略图全部走视口懒加载（首屏前几张视口可见时会立刻加载）
   bindLazyImages(ul, { eagerCount: 0 });
-  renderArticleListViews(ul);
 
   const state = { loaded: firstChunk.length, observer: null, loadNext: null };
   const sentinel = document.getElementById('loadMoreSentinel');
@@ -286,7 +283,6 @@ function renderList(posts) {
     const inserted = [...frag.children];
     inserted.forEach(node => ul.insertBefore(node, sentinel));
     inserted.forEach(node => bindLazyImages(node, { eagerCount: 0 }));
-    inserted.forEach(node => renderArticleListViews(node));
     state.loaded += nextChunk.length;
     if (state.loaded >= posts.length) {
       // 全部加载完，把 sentinel 替换成"到底"提示
@@ -368,7 +364,7 @@ function applyFilter(posts, tab, q, tag) {
 }
 
 (async function init() {
-  // 避免 hero 与 footer 各有一份站点计数（saobby 会加载两张图 +2；不蒜子会重复容器）
+  // 避免 hero 与 footer 各有一份站点 Saobby 图（会各请求一次、+2）
   initSite({ active: './', skipDuplicateSitePv: true });
   setMeta({ title: '', description: CONFIG.site.description, type: 'website' });
   setJsonLd({

--- a/assets/js/pageviews.js
+++ b/assets/js/pageviews.js
@@ -1,138 +1,73 @@
 // ============================================================================
-// 访问计数：支持两种 provider
+// 访问计数（固定双通道）
 //
-//   1. busuanzi（不蒜子）— 默认零配置，按 Referer 自动区分站点 / 单页
-//   2. saobby（https://www.saobby.com）— 需要在站长控制面板各创建一个计数器，
-//      把图片 URL + 控制面板 URL 填进站点设置即可。每张图片放到页面上 = 自带计数 +1
+//   · 站点总访问量（首页 Hero / Footer）：Saobby 计数图片
+//   · 文章页 / 独立页（post.html?slug=…）阅读量：Vercount（events.vercount.one）
 //
-// 模型差异：
-//   - busuanzi：一段 CDN 脚本 + DOM 占位，回填数字
-//   - saobby ：每个计数器 = 一张图，图片 src 加载即 +1，本身就是数字图
-//     ⚠ 一个计数器代表「一类页面」，不能在首页用一张图统计每篇文章的阅读量；
-//        所以 saobby provider 下，首页文章列表的逐篇阅读量会自动隐藏。
-//
-// 加固：
-//   - 没有任何占位元素时，不注入 / 不生成 img（避免无意义请求）
-//   - 配置缺失（saobby.site.img 没填）→ 占位静默隐藏，不影响布局
-//   - busuanzi 5 秒兜底：到点还没拿到数字 → 隐藏所有 .bsz 占位
+// 不再支持不蒜子、Page Views API 或其它 provider。
 // ============================================================================
 
 import { CONFIG } from './config.js';
 
-const BUSUANZI_SRC = 'https://busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js';
-const PAGE_VIEWS_API = 'https://page-views-api.ratneshc.com/api/v1';
+const VCOUNT_DEFAULT_SRC = 'https://events.vercount.one/js';
 
 const STATE = {
-  injected: false,
-  fallbackTimer: null,
+  vercountInjected: false,
 };
-const VIEW_CACHE_KEY = 'article_view_cache_v1';
-const VIEW_CACHE_TTL = 10 * 60 * 1000;
-const LIST_VIEW_CONCURRENCY = 4;
-
-// ---------- provider helpers ----------------------------------------------
 
 function pvCfg() {
   return CONFIG.pageviews || {};
 }
 
-function provider() {
-  const cfg = pvCfg();
-  if (!cfg.enabled) return 'none';
-  return cfg.provider || 'busuanzi';
-}
-
-export function isBusuanziOn() {
-  return provider() === 'busuanzi';
-}
-
-export function isSaobbyOn() {
-  return provider() === 'saobby';
-}
-
 function saobbyCfg() {
-  return (pvCfg().saobby) || {};
+  return pvCfg().saobby || {};
 }
 
 function saobbySiteImg() {
   return String((saobbyCfg().site || {}).img || '').trim();
 }
 
-function saobbyArticleImg() {
-  return String((saobbyCfg().article || {}).img || '').trim();
+function vercountCfg() {
+  return pvCfg().vercount || {};
 }
 
-function articleProvider() {
-  const cfg = pvCfg();
-  return cfg.articleProvider || 'page-views-api';
+function vercountScriptSrc() {
+  const s = String(vercountCfg().scriptSrc || '').trim();
+  return s || VCOUNT_DEFAULT_SRC;
 }
 
-function pageViewsApiOn() {
-  // 仅在 busuanzi 模式下，列表逐篇阅读数才走 Page Views API。
-  // saobby 模式下整个 list 阅读量隐藏，避免误导。
-  return isBusuanziOn() && !!pvCfg().enabled && articleProvider() === 'page-views-api';
+/** 站点级 Saobby 已配置且总开关打开（供后台「访问数据」等判断） */
+export function isSaobbyOn() {
+  const c = pvCfg();
+  return c.enabled !== false && !!saobbySiteImg();
 }
 
-// ---------- busuanzi --------------------------------------------------------
-
-function hideAllBsz(root = document) {
-  root.querySelectorAll('.bsz').forEach(el => { el.style.display = 'none'; });
-}
-
-function hideEmptyBsz(root = document) {
-  root.querySelectorAll('.bsz').forEach(el => {
-    const num = el.querySelector('.bsz-num');
-    if (!num) return;
-    if (!num.textContent || !num.textContent.trim()) el.style.display = 'none';
-  });
-}
-
-function injectBusuanzi() {
-  if (STATE.injected) return;
-  STATE.injected = true;
-  const s = document.createElement('script');
-  s.src = BUSUANZI_SRC;
-  s.async = true;
-  s.referrerPolicy = 'no-referrer-when-downgrade';
-  s.onerror = () => hideAllBsz();
-  document.head.appendChild(s);
-}
-
-function hasBszContainer() {
-  return !!document.querySelector(
-    '#busuanzi_container_site_pv, #busuanzi_container_site_uv, #busuanzi_container_page_pv'
-  );
-}
-
-// ---------- saobby ---------------------------------------------------------
-// 一个 saobby 计数器 = 一张图。我们把图片插入到对应占位里，
-// 浏览器加载这张图就 +1，图本身渲染就是数字。
+// ---------- Saobby（仅站点 slot） -------------------------------------------
 
 function hideAllSaobby(root = document) {
   root.querySelectorAll('[data-saobby-slot]').forEach(el => { el.hidden = true; });
 }
 
-function fillSaobbyImage(slotEl, src, label = '访问') {
+function siteSlotPrefix() {
+  return String(((saobbyCfg().site || {}).label || '总访问')).trim() || '总访问';
+}
+
+function fillSaobbySite(slotEl, src, label = '访问') {
   if (!slotEl) return;
   if (!src) { slotEl.hidden = true; return; }
-  // 在已渲染过的 slot 里插入一张图，避免重复插入
   if (slotEl.dataset.saobbyDone === '1') return;
   slotEl.dataset.saobbyDone = '1';
   slotEl.hidden = false;
-  // 用 data-saobby-prefix / data-saobby-suffix 给纯数字图加上"访问量"/"次"等文字
-  // 让纯数字图配合页面排版有可读性，并在主题切换时和正文一致
   const prefix = String(slotEl.dataset.saobbyPrefix || '').trim();
   const suffix = String(slotEl.dataset.saobbySuffix || '').trim();
   const isStat = slotEl.classList.contains('saobby-slot-stat');
   const numHtml = `<img src="${escapeAttr(src)}" alt="${escapeAttr(label)}" referrerpolicy="no-referrer-when-downgrade" loading="eager" decoding="async" class="saobby-counter">`;
   if (isStat) {
-    // 首页 hero 统一卡片：上面大数字图，下面 label
     slotEl.innerHTML = `
       <strong class="saobby-num">${numHtml}</strong>
       <span class="saobby-label">${escapeAttr(prefix || label)}${suffix ? ' / ' + escapeAttr(suffix) : ''}</span>
     `.trim();
   } else {
-    // 内联（footer / 文章 meta）：[前缀]+[图]+[后缀]
     slotEl.innerHTML = [
       prefix ? `<span class="saobby-prefix">${escapeAttr(prefix)}</span>` : '',
       numHtml,
@@ -145,273 +80,88 @@ function fillSaobbyImage(slotEl, src, label = '访问') {
   }
 }
 
-function siteSlotPrefix() {
-  return String(((saobbyCfg().site || {}).label || '总访问')).trim() || '总访问';
-}
-
-function articleSlotPrefix() {
-  return String(((saobbyCfg().article || {}).label || '阅读')).trim() || '阅读';
-}
-
-function injectSaobby(root = document) {
+function injectSaobbySiteSlots(root = document) {
   const siteImg = saobbySiteImg();
-  const articleImg = saobbyArticleImg();
   const sitePrefix = siteSlotPrefix();
-  const articlePrefix = articleSlotPrefix();
   root.querySelectorAll('[data-saobby-slot="site"]').forEach(el => {
     if (!el.dataset.saobbyPrefix && !el.dataset.saobbySuffix) el.dataset.saobbyPrefix = sitePrefix;
     const override = (el.dataset.saobbyImg || '').trim();
-    fillSaobbyImage(el, override || siteImg, sitePrefix);
-  });
-  root.querySelectorAll('[data-saobby-slot="article"]').forEach(el => {
-    if (!el.dataset.saobbyPrefix && !el.dataset.saobbySuffix) el.dataset.saobbyPrefix = articlePrefix;
-    // 文章页可以通过 data-saobby-img 提供本文专属计数器（来自 frontmatter.counter.img）
-    const override = (el.dataset.saobbyImg || '').trim();
-    fillSaobbyImage(el, override || articleImg, articlePrefix);
+    fillSaobbySite(el, override || siteImg, sitePrefix);
   });
 }
 
-// ---------- public API -----------------------------------------------------
+// ---------- Vercount（仅文章页 #vercount_value_page_pv） --------------------
 
-// 在每个页面入口 / 渲染完成后调用一次。重复调用安全。
+function injectVercountScript() {
+  if (STATE.vercountInjected) return;
+  const el = document.getElementById('vercount_value_page_pv');
+  if (!el) return;
+  const cfg = pvCfg();
+  if (cfg.enabled === false || cfg.showPostViews === false) return;
+  STATE.vercountInjected = true;
+  const s = document.createElement('script');
+  s.src = vercountScriptSrc();
+  s.defer = true;
+  s.referrerPolicy = 'no-referrer-when-downgrade';
+  s.onerror = () => { el.textContent = '—'; };
+  document.head.appendChild(s);
+}
+
+// ---------- public API -------------------------------------------------------
+
 export function initPageviews() {
   const cfg = pvCfg();
-  if (!cfg.enabled || provider() === 'none') {
-    hideAllBsz();
-    hideAllSaobby();
+  if (!cfg.enabled) {
+    hideAllSaobby(document);
     return;
   }
-  if (isBusuanziOn()) {
-    if (!hasBszContainer()) return;
-    injectBusuanzi();
-    if (STATE.fallbackTimer) clearTimeout(STATE.fallbackTimer);
-    STATE.fallbackTimer = setTimeout(() => hideEmptyBsz(), 5000);
-    return;
+  if (saobbySiteImg()) {
+    injectSaobbySiteSlots(document);
+  } else {
+    hideAllSaobby(document);
   }
-  if (isSaobbyOn()) {
-    injectSaobby();
-    return;
-  }
+  injectVercountScript();
 }
 
-// 站点级 PV / UV 占位 HTML（首页 hero / footer 都用它）
+/** 首页 Hero / Footer：站点 Saobby 占位 */
 export function bszSiteStatsHtml({ compact = false } = {}) {
-  if (isBusuanziOn()) {
-    if (compact) {
-      return `
-        <span class="bsz" id="busuanzi_container_site_pv">总访问 <span id="busuanzi_value_site_pv" class="bsz-num"></span></span>
-        <span class="bsz-sep">·</span>
-        <span class="bsz" id="busuanzi_container_site_uv">访客 <span id="busuanzi_value_site_uv" class="bsz-num"></span></span>
-      `;
-    }
-    return `
-      <div class="stat bsz" id="busuanzi_container_site_pv">
-        <strong class="bsz-num"><span id="busuanzi_value_site_pv"></span></strong>次访问
-      </div>
-      <div class="stat bsz" id="busuanzi_container_site_uv">
-        <strong class="bsz-num"><span id="busuanzi_value_site_uv"></span></strong>位访客
-      </div>
-    `;
-  }
-  if (isSaobbyOn() && saobbySiteImg()) {
-    const prefix = siteSlotPrefix();
-    if (compact) {
-      return `<span class="saobby-slot saobby-slot-compact" data-saobby-slot="site" data-saobby-suffix="${escapeAttr(prefix)}" hidden></span>`;
-    }
-    return `<div class="stat saobby-slot saobby-slot-stat" data-saobby-slot="site" data-saobby-prefix="${escapeAttr(prefix)}" hidden></div>`;
-  }
-  return '';
-}
-
-// 文章页阅读次数占位
-//   articleCounterImg 可选：传入本文专属 saobby 图片 URL（来自 frontmatter.counter.img），
-//   优先级高于全站默认 saobby.article.img
-export function bszPagePvHtml({ articleCounterImg = '' } = {}) {
-  if (isBusuanziOn()) {
-    if (pageViewsApiOn()) {
-      return `<span class="pvapi" data-pv-current="1">阅读 <span class="pvapi-num"></span></span>`;
-    }
-    return `<span class="bsz" id="busuanzi_container_page_pv">阅读 <span id="busuanzi_value_page_pv" class="bsz-num"></span></span>`;
-  }
-  if (isSaobbyOn()) {
-    const customImg = String(articleCounterImg || '').trim();
-    if (!customImg && !saobbyArticleImg()) return '';
-    const dataAttr = customImg ? ` data-saobby-img="${escapeAttr(customImg)}"` : '';
-    const prefix = articleSlotPrefix();
-    return `<span class="saobby-slot saobby-slot-inline" data-saobby-slot="article" data-saobby-prefix="${escapeAttr(prefix)}" data-saobby-suffix="次"${dataAttr} hidden></span>`;
-  }
-  return '';
-}
-
-// 首页文章列表逐篇阅读量
-// saobby 模型不支持按 slug 查，直接返回空 → 列表里这一栏不会出现
-export function articleListPvHtml(slug) {
-  if (!slug) return '';
   const cfg = pvCfg();
-  if (cfg.showListPostViews === false || cfg.showPostViews === false) return '';
-  if (isSaobbyOn()) return '';
-  if (!pageViewsApiOn()) return '';
-  return `<span class="post-views pvapi" data-pv-slug="${escapeAttr(slug)}" hidden>阅读 <span class="pvapi-num"></span></span>`;
-}
-
-// 文章页：计数器 +1 并把数字回填到当前页占位
-export async function trackAndRenderArticleView(slug) {
-  if (isSaobbyOn()) {
-    // saobby 走图片即 +1，初始化时已经处理
-    initPageviews();
-    return;
+  if (cfg.enabled === false || !saobbySiteImg()) return '';
+  const prefix = siteSlotPrefix();
+  if (compact) {
+    return `<span class="saobby-slot saobby-slot-compact" data-saobby-slot="site" data-saobby-suffix="${escapeAttr(prefix)}" hidden></span>`;
   }
-  if (!pageViewsApiOn() || !slug) {
-    initPageviews();
-    return;
-  }
-  document.querySelectorAll('[data-pv-current]').forEach(el => {
-    el.dataset.pvSlug = slug;
-  });
-  try {
-    await trackArticleView(slug);
-    const views = await fetchArticleViews(slug);
-    setArticleView(slug, views);
-  } catch (e) {
-    console.warn('[pageviews] render article view failed', e);
-    hideArticleView(slug);
-  }
+  return `<div class="stat saobby-slot saobby-slot-stat" data-saobby-slot="site" data-saobby-prefix="${escapeAttr(prefix)}" hidden></div>`;
 }
 
-// 首页列表批量补阅读量（仅 busuanzi + page-views-api 时才生效）
-export async function renderArticleListViews(root = document) {
-  if (!pageViewsApiOn()) return;
-  const nodes = [...root.querySelectorAll('[data-pv-slug]')].filter(el => !el.dataset.pvLoaded);
-  if (!nodes.length) return;
-  const slugs = [...new Set(nodes.map(el => el.dataset.pvSlug).filter(Boolean))];
-  nodes.forEach(el => { el.dataset.pvLoaded = '1'; });
-  const pending = [];
-  for (const slug of slugs) {
-    const cached = getCachedArticleViews(slug);
-    if (cached != null) {
-      setArticleView(slug, cached);
-    } else {
-      pending.push(slug);
-    }
-  }
-  if (!pending.length) return;
-  scheduleIdle(async () => {
-    for (let i = 0; i < pending.length; i += LIST_VIEW_CONCURRENCY) {
-      const batch = pending.slice(i, i + LIST_VIEW_CONCURRENCY);
-      await Promise.allSettled(batch.map(async slug => {
-        try {
-          const views = await fetchArticleViews(slug);
-          setCachedArticleViews(slug, views);
-          setArticleView(slug, views);
-        } catch (e) {
-          console.warn('[pageviews] list view failed', slug, e);
-          hideArticleView(slug);
-        }
-      }));
-    }
-  });
+/** 文章 meta：Vercount 页阅读量（按当前 URL 区分 slug） */
+export function bszPagePvHtml() {
+  const cfg = pvCfg();
+  if (cfg.enabled === false || cfg.showPostViews === false) return '';
+  const label = String(vercountCfg().label || '阅读').trim() || '阅读';
+  return `<span class="vercount-inline"><span class="vercount-prefix">${escapeHtml(label)} </span><span id="vercount_value_page_pv">…</span><span class="vercount-suffix"> 次</span></span>`;
 }
 
-// ---------- internal: page-views-api ---------------------------------------
-
-function siteKey() {
-  try {
-    const u = new URL(CONFIG.site.url || location.origin);
-    return u.host;
-  } catch {
-    return location.host;
-  }
+/** 已废弃：首页列表不再展示逐篇阅读数 */
+export function articleListPvHtml() {
+  return '';
 }
 
-function basePath() {
-  try {
-    const u = new URL(CONFIG.site.url || location.origin);
-    return u.pathname.replace(/\/+$/, '');
-  } catch {
-    return '';
-  }
+/** 占位：兼容旧 home.js 调用链 */
+export async function renderArticleListViews() {}
+
+export async function trackAndRenderArticleView() {
+  initPageviews();
 }
 
-function articlePath(slug) {
-  const prefix = basePath();
-  const path = `${prefix}/post.html?slug=${encodeURIComponent(slug || '')}`;
-  return path.startsWith('/') ? path : `/${path}`;
-}
-
-async function fetchArticleViews(slug) {
-  const url = `${PAGE_VIEWS_API}/views?site=${encodeURIComponent(siteKey())}&path=${encodeURIComponent(articlePath(slug))}`;
-  const res = await fetch(url, { cache: 'no-store' });
-  if (!res.ok) throw new Error(`views api ${res.status}`);
-  const data = await res.json();
-  return Number(data.views || 0);
-}
-
-function readViewCache() {
-  try {
-    const raw = sessionStorage.getItem(VIEW_CACHE_KEY);
-    const data = raw ? JSON.parse(raw) : {};
-    return data && typeof data === 'object' ? data : {};
-  } catch {
-    return {};
-  }
-}
-
-function writeViewCache(cache) {
-  try { sessionStorage.setItem(VIEW_CACHE_KEY, JSON.stringify(cache)); } catch {}
-}
-
-function getCachedArticleViews(slug) {
-  const item = readViewCache()[slug];
-  if (!item || Date.now() - Number(item.time || 0) > VIEW_CACHE_TTL) return null;
-  return Number(item.views || 0);
-}
-
-function setCachedArticleViews(slug, views) {
-  const cache = readViewCache();
-  cache[slug] = { views: Number(views || 0), time: Date.now() };
-  writeViewCache(cache);
-}
-
-async function trackArticleView(slug) {
-  const url = `${PAGE_VIEWS_API}/track?site=${encodeURIComponent(siteKey())}&path=${encodeURIComponent(articlePath(slug))}`;
-  try {
-    await fetch(url, { cache: 'no-store', keepalive: true });
-  } catch (e) {
-    console.warn('[pageviews] track failed', e);
-  }
-}
-
-function setArticleView(slug, views) {
-  document.querySelectorAll(`[data-pv-slug="${cssEscape(slug)}"]`).forEach(el => {
-    const num = el.querySelector('.pvapi-num');
-    if (num) num.textContent = String(views || 0);
-    el.hidden = false;
-  });
-}
-
-function hideArticleView(slug) {
-  document.querySelectorAll(`[data-pv-slug="${cssEscape(slug)}"]`).forEach(el => {
-    el.hidden = true;
-  });
-}
-
-// ---------- utilities ------------------------------------------------------
-
-function escapeAttr(s) {
+function escapeHtml(s) {
   return String(s == null ? '' : s).replace(/[&<>"']/g, c =>
     ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])
   );
 }
 
-function cssEscape(s) {
-  if (window.CSS && typeof window.CSS.escape === 'function') return window.CSS.escape(String(s));
-  return String(s).replace(/["\\]/g, '\\$&');
-}
-
-function scheduleIdle(fn) {
-  if ('requestIdleCallback' in window) {
-    window.requestIdleCallback(fn, { timeout: 1800 });
-  } else {
-    setTimeout(fn, 900);
-  }
+function escapeAttr(s) {
+  return String(s == null ? '' : s).replace(/[&<>"']/g, c =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])
+  );
 }

--- a/assets/js/post.js
+++ b/assets/js/post.js
@@ -446,12 +446,6 @@ function renderSeriesIndex(allPosts, currentSlug, seriesName) {
   const cover = publicImageUrl((meta && meta.cover) || data.cover || '');
   const tags = (meta && meta.tags) || data.tags || [];
   const summary = (meta && meta.summary) || data.summary || '';
-  // 文章独立 saobby 计数器：frontmatter 优先，posts.json 索引兜底
-  const articleCounter = (data.counter && typeof data.counter === 'object')
-    ? data.counter
-    : ((meta && meta.counter) || null);
-  const articleCounterImg = articleCounter ? String(articleCounter.img || '').trim() : '';
-
   // SEO + 优先用 OG 自动图（assets/og/{slug}.svg）兜底
   const ogAuto = `${CONFIG.site.url || ''}/assets/og/${encodeURIComponent(slug)}.svg`;
   setMeta({
@@ -503,7 +497,7 @@ function renderSeriesIndex(allPosts, currentSlug, seriesName) {
             <span>约 ${mins} 分钟</span>
             ${(() => {
               if ((CONFIG.pageviews || {}).showPostViews === false) return '';
-              const pv = bszPagePvHtml({ articleCounterImg });
+              const pv = bszPagePvHtml();
               return pv ? `<span class="dot"></span>${pv}` : '';
             })()}
           </div>

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -82,7 +82,6 @@ function fillForm(config) {
   renderNavEditor(config.site.nav || []);
   fillThemeTokens(config.theme && config.theme.tokens);
   renderSaobbyExtraEditor((config.pageviews && config.pageviews.saobby && config.pageviews.saobby.extra) || []);
-  applySaobbyVisibility((config.pageviews && config.pageviews.provider) || 'busuanzi');
 }
 
 function fillThemeTokens(tokens) {
@@ -169,11 +168,15 @@ function normalizeConfig(config) {
   config.theme.tokens = config.theme.tokens && typeof config.theme.tokens === 'object' ? config.theme.tokens : {};
   config.theme.customCss = String(config.theme.customCss || '');
   config.analytics = config.analytics || { enabled: false, snippet: '' };
-  config.pageviews = config.pageviews || { enabled: true, provider: 'busuanzi', showHomeStats: true, showPostViews: true, showFooterStats: true };
-  config.pageviews.saobby = config.pageviews.saobby || { site: { img: '', dashboard: '' }, article: { img: '', dashboard: '' }, extra: [] };
-  config.pageviews.saobby.site = config.pageviews.saobby.site || { img: '', dashboard: '' };
-  config.pageviews.saobby.article = config.pageviews.saobby.article || { img: '', dashboard: '' };
+  config.pageviews = config.pageviews || { enabled: true, showHomeStats: true, showPostViews: true, showFooterStats: true };
+  config.pageviews.saobby = config.pageviews.saobby || { site: { img: '', dashboard: '', label: '' }, extra: [] };
+  config.pageviews.saobby.site = config.pageviews.saobby.site || { img: '', dashboard: '', label: '' };
   if (!Array.isArray(config.pageviews.saobby.extra)) config.pageviews.saobby.extra = [];
+  config.pageviews.vercount = config.pageviews.vercount || { scriptSrc: '', label: '' };
+  delete config.pageviews.provider;
+  delete config.pageviews.articleProvider;
+  delete config.pageviews.showListPostViews;
+  if (config.pageviews.saobby.article) delete config.pageviews.saobby.article;
   config.share = config.share || { enabled: true, showInPosts: true, showInPages: false, qrcodeOfPage: true };
   config.share.enabled = config.share.enabled !== false;
   config.share.showInPosts = config.share.showInPosts !== false;
@@ -200,18 +203,15 @@ function normalizeConfig(config) {
   config.analytics.enabled = !!config.analytics.enabled;
   config.analytics.snippet = String(config.analytics.snippet || '').trim();
   config.pageviews.enabled = config.pageviews.enabled !== false;
-  config.pageviews.provider = config.pageviews.provider || 'busuanzi';
-  config.pageviews.articleProvider = config.pageviews.articleProvider || 'page-views-api';
   config.pageviews.showHomeStats = config.pageviews.showHomeStats !== false;
   config.pageviews.showPostViews = config.pageviews.showPostViews !== false;
   config.pageviews.showFooterStats = config.pageviews.showFooterStats !== false;
-  config.pageviews.showListPostViews = config.pageviews.showListPostViews !== false;
-  ['site', 'article'].forEach(k => {
-    const slot = config.pageviews.saobby[k];
-    slot.img = String(slot.img || '').trim();
-    slot.dashboard = String(slot.dashboard || '').trim();
-    slot.label = String(slot.label || (k === 'site' ? '总访问' : '阅读')).trim() || (k === 'site' ? '总访问' : '阅读');
-  });
+  const site = config.pageviews.saobby.site;
+  site.img = String(site.img || '').trim();
+  site.dashboard = String(site.dashboard || '').trim();
+  site.label = String(site.label || '总访问').trim() || '总访问';
+  config.pageviews.vercount.scriptSrc = String(config.pageviews.vercount.scriptSrc || '').trim();
+  config.pageviews.vercount.label = String(config.pageviews.vercount.label || '阅读').trim() || '阅读';
   config.pageviews.saobby.extra = config.pageviews.saobby.extra
     .map(it => ({
       name: String((it && it.name) || '').trim(),
@@ -422,20 +422,6 @@ function bindSaobbyEditor() {
   });
 }
 
-function applySaobbyVisibility(provider) {
-  const root = document;
-  root.querySelectorAll('[data-pv-when]').forEach(el => {
-    const want = el.getAttribute('data-pv-when');
-    el.hidden = (provider !== want);
-  });
-}
-
-function bindPageviewsProvider() {
-  const sel = document.querySelector('select[name="pageviews.provider"]');
-  if (!sel) return;
-  sel.addEventListener('change', () => applySaobbyVisibility(sel.value));
-}
-
 function bindNavEditor() {
   const host = $('#navEditor');
   const addBtn = $('#addNavItem');
@@ -553,46 +539,22 @@ function settingsContentHtml() {
 
       <section class="settings-card">
         <h3>访问计数（前台展示）</h3>
-        <p class="settings-help">在首页、文章页、Footer 上展示阅读 / 访客数字。可在两个 provider 之间切换：<b>busuanzi</b>（零配置，按 Referer 自动区分页面）和 <b>saobby</b>（在 <a href="https://www.saobby.com/create_webcounter" target="_blank" rel="noopener">saobby.com</a> 创建计数器后填入图片 URL；后台「访问数据」可嵌入 saobby 自带的可视化控制面板）。</p>
+        <p class="settings-help">本站固定为双通道：<b>Saobby</b> 统计站点总访问（首页 Hero / Footer 计数图）；<b>Vercount</b> 按页面 URL 统计每篇文章 / 独立页阅读（见 <a href="https://vercount.one" target="_blank" rel="noopener">vercount.one</a>）。二者互不影响。</p>
         <div class="settings-grid">
           <label class="settings-check"><input type="checkbox" name="pageviews.enabled"> 启用访问计数</label>
-          <label>provider
-            <select name="pageviews.provider" id="pvProviderSelect">
-              <option value="busuanzi">busuanzi（不蒜子）</option>
-              <option value="saobby">saobby（saobby.com）</option>
-              <option value="none">none（仅占位禁用）</option>
-            </select>
-            <span class="settings-hint" data-pv-when="busuanzi">无需注册、按 Referer 自动隔离站点；服务挂掉时占位会自动隐藏。</span>
-            <span class="settings-hint" data-pv-when="saobby">每个 saobby 计数器 = 一张图。把图片 URL 填到下方，控制面板 URL 用于后台「访问数据」嵌入。</span>
-          </label>
-          <label data-pv-when="busuanzi">文章阅读数 provider
-            <select name="pageviews.articleProvider">
-              <option value="page-views-api">Page Views API（支持首页文章列表）</option>
-              <option value="busuanzi">busuanzi（仅文章页当前页）</option>
-            </select>
-            <span class="settings-hint">首页要展示每篇文章阅读量时，推荐 Page Views API；它按 slug 查询，不会因首页展示而增加阅读数。</span>
-          </label>
-          <label class="settings-check"><input type="checkbox" name="pageviews.showHomeStats"> 首页 Hero 显示总访问 / 访客</label>
-          <label class="settings-check"><input type="checkbox" name="pageviews.showPostViews"> 文章页显示阅读次数</label>
-          <label class="settings-check"><input type="checkbox" name="pageviews.showFooterStats"> Footer 显示站点 PV / UV</label>
-          <label class="settings-check" data-pv-when="busuanzi"><input type="checkbox" name="pageviews.showListPostViews"> 首页文章列表显示逐篇阅读量</label>
+          <label class="settings-check"><input type="checkbox" name="pageviews.showHomeStats"> 首页 Hero 显示站点访问（Saobby）</label>
+          <label class="settings-check"><input type="checkbox" name="pageviews.showPostViews"> 文章页显示阅读次数（Vercount）</label>
+          <label class="settings-check"><input type="checkbox" name="pageviews.showFooterStats"> Footer 显示站点访问（Saobby）</label>
         </div>
       </section>
 
-      <section class="settings-card" data-pv-when="saobby">
-        <h3>Saobby 计数器配置</h3>
-        <p class="settings-help">在 <a href="https://www.saobby.com/create_webcounter" target="_blank" rel="noopener">saobby.com / 创建网页计数器</a> 创建后会得到一张计数图片，把图片 URL 与控制面板 URL（含 key）粘到这里即可。后台「访问数据」会用 iframe 嵌入这些控制面板。</p>
-        <div class="settings-row-title"><span>站点级计数器（首页 Hero / Footer）</span></div>
+      <section class="settings-card">
+        <h3>Saobby（站点总访问）</h3>
+        <p class="settings-help">在 <a href="https://www.saobby.com/create_webcounter" target="_blank" rel="noopener">saobby.com</a> 创建计数器后，把图片 URL 与控制面板 URL 粘到下方。后台「访问数据」可 iframe 嵌入控制面板。</p>
         <div class="settings-grid">
           <label class="span-2">图片 URL <input name="pageviews.saobby.site.img" placeholder="https://www.saobby.com/webcounter/svg?id=..."></label>
           <label class="span-2">控制面板 URL <input name="pageviews.saobby.site.dashboard" placeholder="https://www.saobby.com/webcounter_dashboard?key=..."></label>
-          <label>前缀文字 <input name="pageviews.saobby.site.label" placeholder="总访问"><span class="settings-hint">显示在数字图前面，例如「总访问」「访客数」</span></label>
-        </div>
-        <div class="settings-row-title" style="margin-top:14px"><span>文章页计数器（每篇文章共用一张图）</span></div>
-        <div class="settings-grid">
-          <label class="span-2">图片 URL <input name="pageviews.saobby.article.img" placeholder="可选，留空则文章页不显示阅读次数"></label>
-          <label class="span-2">控制面板 URL <input name="pageviews.saobby.article.dashboard" placeholder="https://www.saobby.com/webcounter_dashboard?key=..."></label>
-          <label>前缀文字 <input name="pageviews.saobby.article.label" placeholder="阅读"><span class="settings-hint">显示在数字图前面，例如「阅读」「访问」</span></label>
+          <label>前缀文字 <input name="pageviews.saobby.site.label" placeholder="总访问"><span class="settings-hint">显示在计数图旁，例如「总访问」</span></label>
         </div>
         <div class="settings-row-title" style="margin-top:14px">
           <span>额外计数器（仅在后台「访问数据」展示）</span>
@@ -600,7 +562,16 @@ function settingsContentHtml() {
         </div>
         <div class="saobby-extra-editor" id="saobbyExtraEditor"></div>
         <textarea name="pageviews.saobby.extra" hidden></textarea>
-        <p class="settings-help">用于跟踪首页之外的特定页面（例如「关于」「随笔列表」），方便分别看数据。</p>
+        <p class="settings-help">用于跟踪其它落地页的 Saobby 图（例如单独推广的页面）。</p>
+      </section>
+
+      <section class="settings-card">
+        <h3>Vercount（文章 / 独立页阅读）</h3>
+        <p class="settings-help">文章页会加载官方脚本并显示 <code>#vercount_value_page_pv</code>。留空脚本地址则使用默认 <code>https://events.vercount.one/js</code>；自托管请改成你的脚本 URL。统计需在 <a href="https://vercount.one" target="_blank" rel="noopener">vercount.one</a> 验证域名后查看。</p>
+        <div class="settings-grid">
+          <label class="span-2">脚本 URL（可选） <input name="pageviews.vercount.scriptSrc" placeholder="https://events.vercount.one/js"></label>
+          <label>前缀文字 <input name="pageviews.vercount.label" placeholder="阅读"><span class="settings-hint">显示在数字前，例如「阅读」「浏览」</span></label>
+        </div>
       </section>
 
       <section class="settings-card">
@@ -738,7 +709,6 @@ function topActions() {
   fillForm(state.current);
   bindNavEditor();
   bindSaobbyEditor();
-  bindPageviewsProvider();
   bindThemePanel();
   await loadRemoteConfigSha();
 

--- a/scripts/release-template/config.js
+++ b/scripts/release-template/config.js
@@ -61,28 +61,22 @@ export const CONFIG = {
   },
   pageviews: {
     enabled: true,
-    // busuanzi（不蒜子，零配置）/ saobby（saobby.com 计数器，需注册）/ none
-    provider: "busuanzi",
-    // busuanzi 模式下首页文章列表的逐篇阅读量来源
-    articleProvider: "page-views-api",
     showHomeStats: true,
     showPostViews: true,
     showFooterStats: true,
-    showListPostViews: true,
-    // saobby 计数器：在 https://www.saobby.com/create_webcounter 创建，
-    // 把生成的图片 URL 和控制面板（dashboard）URL 粘进来即可
+    // 站点总访问：Saobby 计数图（首页 Hero / Footer）
     saobby: {
       site: {
-        img: "",          // 站点级计数器图片 URL（首页 / footer 展示）
-        dashboard: "",    // 站点计数器控制面板完整 URL（含 key），后台「访问数据」会嵌入
-        label: "总访问"    // 前缀文字，例如改成「访客数」「累计访问」
+        img: "",          // 站点级计数器图片 URL
+        dashboard: "",    // 控制面板 URL（后台「访问数据」iframe）
+        label: "总访问"
       },
-      article: {
-        img: "",          // 文章页计数器（每篇文章共用一张图，统计全站文章总阅读）
-        dashboard: "",
-        label: "阅读"
-      },
-      extra: []           // [{ name, img, dashboard }] 额外计数器，仅在后台「访问数据」展示
+      extra: []           // [{ name, img, dashboard }] 额外计数器
+    },
+    // 文章 / 独立页阅读：Vercount（https://vercount.one），按当前页面 URL 区分
+    vercount: {
+      scriptSrc: "",      // 默认可留空，使用 https://events.vercount.one/js
+      label: "阅读"       // 显示在数字前的文案
     }
   },
   auth: {

--- a/sw.js
+++ b/sw.js
@@ -46,7 +46,7 @@ self.addEventListener('activate', event => {
   );
 });
 
-// 不要拦截 GitHub API、giscus、busuanzi、cdn 这些跨域 / 鉴权资源
+// 不要拦截 GitHub API、giscus、Vercount events、cdn 等跨域资源
 function shouldHandle(request) {
   if (request.method !== 'GET') return false;
   const url = new URL(request.url);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 目标

- **站点总访问量**（首页 Hero / Footer）：仅 **Saobby** 计数图（与现有一致）。
- **文章页 / 独立页**（`post.html?slug=…`）：仅 **Vercount**（`#vercount_value_page_pv` + `https://events.vercount.one/js`，可在设置里改脚本 URL）。
- **移除**：不蒜子、Page Views API、首页列表逐篇 PV、`pageviews.provider` / `articleProvider`、Saobby「文章页共用」配置与编辑器里 per-post Saobby 面板。

## 配置迁移

`normalizeConfig` 会在保存/加载时去掉 `provider`、`articleProvider`、`showListPostViews`、`saobby.article` 等旧字段，并补上 `pageviews.vercount: { scriptSrc, label }`。

## 运营说明

- 文章阅读需在 [vercount.one](https://vercount.one) 验证域名后查看控制台。
- 后台「文章管理」阅读量 Top 10 已删除，改为说明文案指向 Vercount / Saobby。
- 「访问数据」仅嵌入 Saobby 站点 + 额外计数器 iframe。

草稿 PR，合并后请在后台保存一次设置以持久化新结构。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

