### PR TITLE
feat: 随笔页内联发布 + 首页 Tab 改为最新/系列/随笔

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add sitemap.xml rss.xml robots.txt manifest.webmanifest data/posts.json assets/og
+          git add sitemap.xml rss.xml robots.txt manifest.webmanifest data/posts.json data/notes.json data/search.json assets/og
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -450,6 +450,17 @@
   font-weight: 500;
 }
 
+.post-note-badge {
+  display: inline-block;
+  margin-right: 6px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-weight: 500;
+}
+
 .post-title {
   font-size: 18px;
   font-weight: 700;

--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -235,6 +235,7 @@ function postItemHtml(p, author, avatar) {
         <h3 class="post-title">${escapeHtml(p.title || '无标题')}</h3>
         <p class="post-summary">${escapeHtml(p.summary || '')}</p>
         <div class="post-meta">
+          ${p.isNote ? '<span class="post-note-badge">随笔</span>' : ''}
           ${(p.tags || []).slice(0, 3).map(t => tagHtml(t)).join('')}
         </div>
       </a>
@@ -246,13 +247,18 @@ function postItemHtml(p, author, avatar) {
 // 懒加载状态：每次切 tab/筛选都会被替换
 let listState = null;
 
-function renderList(posts) {
+function renderList(posts, tab = 'latest') {
   const ul = $('#postList');
   // 销毁上一次的观察器
   if (listState && listState.observer) listState.observer.disconnect();
 
   if (!posts.length) {
-    ul.innerHTML = '<li class="empty">还没有文章。点击右上角"写文章"开始第一篇～</li>';
+    const emptyMsg = tab === 'series'
+      ? '暂无归入系列的文章（在文章 frontmatter 里设置 series 即可）'
+      : tab === 'notes'
+        ? '还没有随笔。登录后可在「随笔」页直接发布～'
+        : '还没有文章。点击右上角"写文章"开始第一篇～';
+    ul.innerHTML = `<li class="empty">${emptyMsg}</li>`;
     listState = null;
     return;
   }
@@ -336,8 +342,39 @@ function renderRecent(posts) {
   `).join('');
 }
 
-function applyFilter(posts, tab, q, tag) {
-  let r = [...posts];
+function plainSnippetFromMd(md, max = 160) {
+  return String(md || '')
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/!\[.*?\]\(.*?\)/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[#>*_`~]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, max);
+}
+
+function noteEntriesForHome(notes) {
+  return (notes || []).map(n => ({
+    slug: n.slug,
+    title: n.title || plainSnippetFromMd(n.content, 48) || '随笔',
+    summary: plainSnippetFromMd(n.content, 220),
+    tags: n.tags || [],
+    date: n.date,
+    author: n.author,
+    pinned: false,
+    cover: null,
+    isNote: true,
+  }));
+}
+
+function buildHomeList({ allPosts, noteRows, tab, q, tag }) {
+  let r;
+  if (tab === 'notes') {
+    r = noteEntriesForHome(noteRows);
+  } else {
+    r = [...allPosts];
+    if (tab === 'series') r = r.filter(p => String(p.series || '').trim());
+  }
   if (q) {
     const lq = q.toLowerCase();
     r = r.filter(p =>
@@ -347,10 +384,8 @@ function applyFilter(posts, tab, q, tag) {
     );
   }
   if (tag) r = r.filter(p => (p.tags || []).includes(tag));
-  if (tab === 'hot') {
-    r.sort((a, b) => (b.views || 0) - (a.views || 0));
-  } else if (tab === 'all') {
-    r.sort((a, b) => String(a.title || '').localeCompare(String(b.title || ''), 'zh-CN'));
+  if (tab === 'notes') {
+    r.sort((a, b) => new Date(b.date || 0) - new Date(a.date || 0));
   } else {
     r.sort((a, b) => {
       if ((b.pinned ? 1 : 0) !== (a.pinned ? 1 : 0)) return (b.pinned ? 1 : 0) - (a.pinned ? 1 : 0);
@@ -387,13 +422,23 @@ function applyFilter(posts, tab, q, tag) {
   });
 
   let allPosts = [];
+  let noteRows = [];
   try {
     const data = await fetchIndexPublic();
-    // 短动态（type:note）单独入口 notes.html，不挤进首页文章流
+    // 短动态（type:note）单独入口 notes.html；首页「随笔」tab 另拉 notes.json 展示
     allPosts = (Array.isArray(data.posts) ? data.posts : []).filter(p => !p.draft && p.type !== 'note');
   } catch (e) {
     $('#postList').innerHTML = `<li class="error">加载文章列表失败：${escapeHtml(e.message)}</li>`;
     return;
+  }
+  try {
+    const r = await fetch('data/notes.json?_=' + Date.now(), { cache: 'no-cache' });
+    if (r.ok) {
+      const j = await r.json();
+      noteRows = Array.isArray(j.notes) ? j.notes : [];
+    }
+  } catch {
+    noteRows = [];
   }
 
   renderHero(allPosts);
@@ -414,7 +459,8 @@ function applyFilter(posts, tab, q, tag) {
         const o = JSON.parse(raw);
         if (typeof o.y === 'number' && o.y >= 0 && Number.isFinite(o.y)) {
           pendingRestore = o;
-          if (o.tab === 'hot' || o.tab === 'all' || o.tab === 'latest') tab = o.tab;
+          if (o.tab === 'latest' || o.tab === 'series' || o.tab === 'notes') tab = o.tab;
+          else if (o.tab === 'hot' || o.tab === 'all') tab = 'latest';
           if (typeof o.tag === 'string') activeTag = o.tag;
         }
       }
@@ -424,8 +470,8 @@ function applyFilter(posts, tab, q, tag) {
   }
 
   function refresh() {
-    const filtered = applyFilter(allPosts, tab, '', activeTag);
-    renderList(filtered);
+    const filtered = buildHomeList({ allPosts, noteRows, tab, q: '', tag: activeTag });
+    renderList(filtered, tab);
     if (pendingRestore) {
       const pr = pendingRestore;
       pendingRestore = null;

--- a/assets/js/notes.js
+++ b/assets/js/notes.js
@@ -1,39 +1,247 @@
 // ============================================================================
 // 短动态（type: note）时间线页面
-// 直接拉 data/notes.json（含每条 note 的完整 markdown），渲染为时间轴卡片
+// 拉 data/notes.json 渲染；已登录且白名单用户显示简易发布框（直写 posts/*.md）
 // ============================================================================
 
 import { CONFIG } from './config.js';
 import { initSite, escapeHtml, fmtDate, timeAgo, tagHtml } from './site.js';
-import { renderMarkdown } from './markdown.js';
+import { renderMarkdown, stringifyFrontmatter, extractSummary, slugify } from './markdown.js';
 import { setMeta } from './seo.js';
+import { writeFile, uploadImage } from './api.js';
+import { getToken, getUser, isAuthorized, rememberReturnTo, logout } from './auth.js';
 
 const $ = sel => document.querySelector(sel);
 
-(async function init() {
-  initSite({ active: 'notes' });
-  setMeta({
-    title: '随笔',
-    description: '不成体系的小想法、灵感与备忘',
-  });
+function showToast(msg, kind = '') {
+  const t = document.createElement('div');
+  t.className = 'toast' + (kind ? ' ' + kind : '');
+  t.textContent = msg;
+  document.body.appendChild(t);
+  requestAnimationFrame(() => t.classList.add('show'));
+  setTimeout(() => {
+    t.classList.remove('show');
+    setTimeout(() => t.remove(), 200);
+  }, 2600);
+}
 
-  let notes = [];
-  try {
-    const r = await fetch('data/notes.json?_=' + Date.now(), { cache: 'no-cache' });
-    if (r.ok) {
-      const j = await r.json();
-      notes = Array.isArray(j.notes) ? j.notes : [];
-    }
-  } catch (e) {
-    console.warn('[notes] load failed', e);
+function uniqueTags(tags) {
+  const seen = new Set();
+  const list = [];
+  for (const raw of tags || []) {
+    const tag = String(raw || '').trim();
+    if (!tag || seen.has(tag)) continue;
+    seen.add(tag);
+    list.push(tag);
+  }
+  return list;
+}
+
+function parseTagsInput(s) {
+  return uniqueTags(String(s || '').split(/[,，]/).map(x => x.trim()).filter(Boolean));
+}
+
+function insertAtCursor(ta, text) {
+  if (!ta) return;
+  const start = ta.selectionStart ?? ta.value.length;
+  const end = ta.selectionEnd ?? ta.value.length;
+  ta.value = ta.value.slice(0, start) + text + ta.value.slice(end);
+  const pos = start + text.length;
+  ta.setSelectionRange(pos, pos);
+  ta.focus();
+}
+
+function defaultNoteTitle() {
+  const d = new Date();
+  const pad = n => String(n).padStart(2, '0');
+  return `随笔 · ${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function makeNoteSlug(titleForSlug) {
+  const base = slugify(titleForSlug || 'note');
+  return `${base}-${Date.now().toString(36)}`;
+}
+
+function setComposeStatus(text, cls = '') {
+  const el = $('#noteComposeStatus');
+  if (!el) return;
+  el.textContent = text || '';
+  el.className = 'note-composer-tip' + (cls ? ' ' + cls : '');
+}
+
+async function publishNoteFromPage() {
+  if (!getToken()) {
+    showToast('请先登录', 'error');
+    return;
+  }
+  if (!isAuthorized()) {
+    showToast('当前账号不在白名单内', 'error');
+    return;
   }
 
+  const titleInput = ($('#noteComposeTitle') && $('#noteComposeTitle').value.trim()) || '';
+  const bodyEl = $('#noteComposeBody');
+  const content = (bodyEl && bodyEl.value || '').trim();
+  if (!content) {
+    setComposeStatus('正文不能为空', 'error');
+    return;
+  }
+
+  const title = titleInput || defaultNoteTitle();
+  const tags = parseTagsInput($('#noteComposeTags') && $('#noteComposeTags').value);
+  const finalTags = tags.length ? tags : ['随笔'];
+  const author = (getUser() && getUser().name) || CONFIG.site.author || '';
+  const now = new Date().toISOString();
+  const summary = extractSummary(content, 120);
+
+  const fm = {
+    title,
+    date: now,
+    updated: now,
+    author,
+    tags: finalTags,
+    type: 'note',
+    summary,
+  };
+
+  const md = stringifyFrontmatter(fm, content.endsWith('\n') ? content : content + '\n');
+  const slug = makeNoteSlug(titleInput || title);
+  const path = `${CONFIG.paths.posts}/${slug}.md`;
+
+  const btn = $('#noteComposePublish');
+  if (btn) btn.disabled = true;
+  setComposeStatus('正在提交到 GitHub…');
+
+  try {
+    await writeFile(path, md, `note: 发布 ${title}`, null);
+    setComposeStatus('已保存。仓库构建完成后会出现在列表与首页「随笔」栏。', 'ok');
+    showToast('发布成功');
+    if (bodyEl) bodyEl.value = '';
+    if ($('#noteComposeTitle')) $('#noteComposeTitle').value = '';
+    const iso = now;
+    const html = await renderMarkdown(content);
+    const list = $('#noteList');
+    const empty = list && list.querySelector('.notes-empty');
+    if (empty) empty.remove();
+    if (list) {
+      const li = document.createElement('li');
+      li.className = 'note-item';
+      li.innerHTML = `
+      <div class="note-meta">
+        <span>${escapeHtml(author)}</span>
+        <span>·</span>
+        <span title="${escapeHtml(iso)}">刚刚</span>
+      </div>
+      <div class="note-content">${html}</div>
+      ${finalTags.length ? `<div class="note-tags">${finalTags.map(t => tagHtml(t, { href: 'tags.html#' + encodeURIComponent(t) })).join('')}</div>` : ''}
+    `;
+      list.insertBefore(li, list.firstChild);
+    }
+  } catch (e) {
+    console.error(e);
+    if (e.status === 401) {
+      logout(window.location.href);
+      return;
+    }
+    setComposeStatus(e.message || '发布失败', 'error');
+    showToast(e.message || '发布失败', 'error');
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
+
+async function handleComposeImages(files) {
+  if (!getToken() || !isAuthorized()) {
+    showToast('请先登录', 'error');
+    return;
+  }
+  const ta = $('#noteComposeBody');
+  for (const file of files) {
+    if (!file.type.startsWith('image/')) continue;
+    setComposeStatus(`上传 ${file.name}…`);
+    try {
+      const path = await uploadImage(file, file.name);
+      const url = path.startsWith('http') ? path : path.replace(/^\.\//, '');
+      const md = `\n![${file.name.replace(/]/g, '')}](${url})\n`;
+      insertAtCursor(ta, md);
+      setComposeStatus('');
+    } catch (e) {
+      console.error(e);
+      if (e.status === 401) { logout(window.location.href); return; }
+      setComposeStatus(e.message || '上传失败', 'error');
+    }
+  }
+}
+
+function mountComposer() {
+  const wrap = $('#noteComposerWrap');
+  const hint = $('#noteLoginHint');
+  const token = getToken();
+  const ok = token && isAuthorized();
+  if (wrap) wrap.hidden = !ok;
+  if (hint) hint.hidden = ok;
+
+  const loginLink = $('#noteLoginLink');
+  if (loginLink) {
+    loginLink.addEventListener('click', e => {
+      e.preventDefault();
+      rememberReturnTo(window.location.href);
+      window.location.href = 'admin/index.html';
+    });
+  }
+
+  if (!ok) return;
+
+  const ta = $('#noteComposeBody');
+  const pick = $('#noteComposePickImg');
+  const fileInp = $('#noteComposeFile');
+  const pub = $('#noteComposePublish');
+
+  if (pick && fileInp) {
+    pick.addEventListener('click', () => fileInp.click());
+    fileInp.addEventListener('change', () => {
+      const f = fileInp.files;
+      if (f && f.length) handleComposeImages([...f]);
+      fileInp.value = '';
+    });
+  }
+
+  if (ta) {
+    ta.addEventListener('paste', e => {
+      const items = e.clipboardData && e.clipboardData.items;
+      if (!items) return;
+      const imgs = [];
+      for (const it of items) {
+        if (it.kind === 'file' && it.type.startsWith('image/')) {
+          const f = it.getAsFile();
+          if (f) imgs.push(f);
+        }
+      }
+      if (imgs.length) {
+        e.preventDefault();
+        handleComposeImages(imgs);
+      }
+    });
+    ta.addEventListener('dragover', e => { e.preventDefault(); });
+    ta.addEventListener('drop', e => {
+      e.preventDefault();
+      const dt = e.dataTransfer;
+      if (!dt || !dt.files || !dt.files.length) return;
+      handleComposeImages([...dt.files]);
+    });
+  }
+
+  if (pub) pub.addEventListener('click', () => publishNoteFromPage());
+}
+
+async function renderNoteList(notes) {
   const list = $('#noteList');
   if (!notes.length) {
     list.innerHTML = `
       <li class="notes-empty">
         还没有任何短动态。<br>
-        在编辑器里把 frontmatter 的 <code>type</code> 设为 <code>note</code> 就会出现在这里。
+        ${getToken() && isAuthorized()
+          ? '在上方写一条并发送，或到后台编辑器把文章的 <code>type</code> 设为 <code>note</code>。'
+          : '在编辑器里把 frontmatter 的 <code>type</code> 设为 <code>note</code> 就会出现在这里。'}
       </li>
     `;
     return;
@@ -51,4 +259,27 @@ const $ = sel => document.querySelector(sel);
       ${(n.tags && n.tags.length) ? `<div class="note-tags">${n.tags.map(t => tagHtml(t, { href: 'tags.html#' + encodeURIComponent(t) })).join('')}</div>` : ''}
     </li>
   `).join('');
+}
+
+(async function init() {
+  initSite({ active: 'notes.html' });
+  setMeta({
+    title: '随笔',
+    description: '不成体系的小想法、灵感与备忘',
+  });
+
+  mountComposer();
+
+  let notes = [];
+  try {
+    const r = await fetch('data/notes.json?_=' + Date.now(), { cache: 'no-cache' });
+    if (r.ok) {
+      const j = await r.json();
+      notes = Array.isArray(j.notes) ? j.notes : [];
+    }
+  } catch (e) {
+    console.warn('[notes] load failed', e);
+  }
+
+  await renderNoteList(notes);
 })();

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta name="description" content="">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
   <link rel="stylesheet" href="assets/css/common.css?v=20260512184000">
-  <link rel="stylesheet" href="assets/css/home.css?v=20260512184000">
+  <link rel="stylesheet" href="assets/css/home.css?v=20260513180000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
@@ -25,8 +25,8 @@
     <section>
       <div class="tabs">
         <div class="tab active" data-tab="latest">最新</div>
-        <div class="tab" data-tab="hot">热门</div>
-        <div class="tab" data-tab="all">全部</div>
+        <div class="tab" data-tab="series">系列</div>
+        <div class="tab" data-tab="notes">随笔</div>
       </div>
       <ul id="postList" class="post-list">
         <li class="loading">加载中…</li>
@@ -47,6 +47,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="assets/js/home.js?v=20260512184000"></script>
+  <script type="module" src="assets/js/home.js?v=20260513180000"></script>
 </body>
 </html>

--- a/notes.html
+++ b/notes.html
@@ -6,8 +6,8 @@
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>随笔 · 加载中…</title>
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
-  <link rel="stylesheet" href="assets/css/common.css?v=20260512184000">
-  <link rel="stylesheet" href="assets/css/home.css?v=20260512184000">
+  <link rel="stylesheet" href="assets/css/common.css?v=20260513180000">
+  <link rel="stylesheet" href="assets/css/home.css?v=20260513180000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <style>
     .notes-page { max-width: 720px; margin: 28px auto; padding: 0 24px; }
@@ -69,6 +69,80 @@
       color: var(--text-tertiary);
       padding: 60px 20px;
     }
+    .note-login-hint {
+      font-size: 14px;
+      color: var(--text-secondary);
+      margin-bottom: 20px;
+      padding: 12px 14px;
+      border: 1px dashed var(--border);
+      border-radius: var(--radius);
+      background: var(--bg-secondary);
+    }
+    .note-login-hint a { color: var(--primary); font-weight: 600; }
+    .note-composer-wrap { margin-bottom: 28px; }
+    .note-composer {
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 16px 18px;
+      background: var(--bg-secondary);
+    }
+    .note-composer-hd {
+      font-size: 15px;
+      font-weight: 700;
+      margin-bottom: 14px;
+      color: var(--text-main);
+    }
+    .note-composer-label {
+      display: block;
+      font-size: 13px;
+      color: var(--text-secondary);
+      margin-bottom: 6px;
+    }
+    .note-composer-label .hint { font-weight: 400; color: var(--text-tertiary); font-size: 12px; }
+    .note-composer-input {
+      width: 100%;
+      box-sizing: border-box;
+      margin-bottom: 12px;
+      padding: 8px 10px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-size: 14px;
+      background: var(--bg);
+      color: var(--text-main);
+    }
+    .note-composer-textarea {
+      width: 100%;
+      box-sizing: border-box;
+      margin-bottom: 12px;
+      padding: 10px 12px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-size: 14px;
+      line-height: 1.6;
+      min-height: 140px;
+      resize: vertical;
+      background: var(--bg);
+      color: var(--text-main);
+      font-family: var(--font-mono, ui-monospace, monospace);
+    }
+    .note-composer-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: center;
+      margin-bottom: 8px;
+    }
+    .note-composer-actions .btn {
+      padding: 8px 16px;
+      border-radius: 6px;
+      font-size: 14px;
+      cursor: pointer;
+      font-weight: 600;
+    }
+    .note-composer-actions .btn:disabled { opacity: 0.55; cursor: not-allowed; }
+    .note-composer-tip { font-size: 12px; color: var(--text-tertiary); margin: 0; min-height: 1.2em; }
+    .note-composer-tip.error { color: #c0392b; }
+    .note-composer-tip.ok { color: var(--primary); }
     @media (max-width: 720px) {
       .notes-page { margin: 16px auto; padding: 0 14px; }
       .notes-page h1 { font-size: 20px; }
@@ -89,6 +163,24 @@
   <main class="notes-page">
     <h1>随笔</h1>
     <p class="desc">不成体系的小想法、灵感与备忘 · 时间倒序展示</p>
+    <p class="note-login-hint" id="noteLoginHint" hidden>登录后可在此直接发布随笔（写入仓库后由 GitHub Actions 重建索引）。<a href="admin/index.html" id="noteLoginLink">去登录</a></p>
+    <div class="note-composer-wrap" id="noteComposerWrap" hidden>
+      <div class="note-composer">
+        <div class="note-composer-hd">发条随笔</div>
+        <label class="note-composer-label">标题 <span class="hint">（可选）</span></label>
+        <input type="text" id="noteComposeTitle" class="note-composer-input" maxlength="120" placeholder="留空则使用「随笔 · 日期时间」" autocomplete="off" />
+        <label class="note-composer-label">标签 <span class="hint">（逗号分隔，默认 随笔）</span></label>
+        <input type="text" id="noteComposeTags" class="note-composer-input" placeholder="随笔" autocomplete="off" />
+        <label class="note-composer-label">正文 <span class="hint">（支持 Markdown；可粘贴或拖拽图片）</span></label>
+        <textarea id="noteComposeBody" class="note-composer-textarea" rows="7"></textarea>
+        <div class="note-composer-actions">
+          <button type="button" class="btn btn-secondary" id="noteComposePickImg">插入图片</button>
+          <input type="file" id="noteComposeFile" accept="image/*" multiple hidden />
+          <button type="button" class="btn btn-primary" id="noteComposePublish">发送</button>
+        </div>
+        <p class="note-composer-tip" id="noteComposeStatus"></p>
+      </div>
+    </div>
     <ul class="note-list" id="noteList">
       <li class="notes-empty">加载中…</li>
     </ul>
@@ -97,6 +189,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="assets/js/notes.js?v=20260512184000"></script>
+  <script type="module" src="assets/js/notes.js?v=20260513180000"></script>
 </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 随笔页（已登录）

- 在 `notes.html` 顶部增加简易发布区：可选标题、标签（默认 `随笔`）、Markdown 正文。
- 支持**粘贴图片**、**拖拽图片**、**选择文件插入**（走现有 `uploadImage` → `assets/uploads/...`）。
- 点击「发送」通过 GitHub API 写入 `posts/<slug>.md`，frontmatter 含 `type: note` 与摘要；**不写** `data/posts.json`（与后台发文章一致，交给 `node scripts/build.mjs` 重建）。
- 成功后清空输入，并在时间线**顶部插入**刚发的一条预览；全站 `data/notes.json` 需等 Actions 构建后更新。

未登录时显示「去登录」提示（跳转 `admin/index.html` 并记住返回 `notes.html`）。

## 首页瀑布流 Tab

- 「最新」「**系列**」「**随笔**」：`系列` 仅展示带 `series` 的文章；`随笔` 使用 `data/notes.json` 与随笔页同源数据。
- 旧版 session 里保存的 `hot` / `all` 会回落为 `latest`。

## CI

- `build` 工作流在提交生成结果时一并 `git add` **`data/notes.json`** 与 **`data/search.json`**，避免只重建了本地文件却未入库导致随笔列表长期不更新。

## 其它

- 随笔页导航高亮改为 `notes.html`（与 `config.js` 里 nav 的 `href` 一致）。
- 首页「随笔」列表项增加小徽章样式 `post-note-badge`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

