### PR TITLE
fix: index fetch from /post/.../ + date URLs

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -140,6 +140,27 @@ export async function listDir(path) {
   }
 }
 
+// ---------- 站点根路径（与 site.js 中 siteBasePath 一致，避免 api ↔ site 循环依赖）----------
+function siteBasePathFromConfig() {
+  try {
+    const u = String(CONFIG.site.url || '').trim();
+    if (!u) return '';
+    const o = new URL(u.endsWith('/') ? u : `${u}/`);
+    const p = o.pathname.replace(/\/+$/, '');
+    return p === '/' || !p ? '' : p;
+  } catch {
+    return '';
+  }
+}
+
+/** 从 /post/.../ 等子路径发起 fetch 时须用站点根下的绝对 path（以 / 开头） */
+function publicAssetAbsPath(relPath) {
+  const r = String(relPath || '').replace(/^\//, '');
+  const bp = siteBasePathFromConfig();
+  if (!bp) return `/${r}`;
+  return `${bp}/${r}`.replace(/\/{2,}/g, '/');
+}
+
 // ---------- 文章索引 ----------
 // posts.json 形如：
 // { posts: [ { slug, title, date, summary, tags, author, cover, path } ] }
@@ -158,7 +179,7 @@ export async function readIndex() {
 
 // 用 fetch 直接拿静态文件版本（首页未登录时使用，避免 API 限流）
 export async function fetchIndexPublic() {
-  const url = `./${CONFIG.paths.index}?t=${Date.now()}`;
+  const url = `${publicAssetAbsPath(CONFIG.paths.index)}?t=${Date.now()}`;
   try {
     const res = await fetch(url, { cache: 'no-cache' });
     if (!res.ok) return { posts: [] };
@@ -169,7 +190,8 @@ export async function fetchIndexPublic() {
 }
 
 export async function fetchPostMarkdownPublic(slug) {
-  const url = `./${CONFIG.paths.posts}/${encodeURIComponent(slug)}.md?t=${Date.now()}`;
+  const rel = `${CONFIG.paths.posts}/${encodeURIComponent(slug)}.md`;
+  const url = `${publicAssetAbsPath(rel)}?t=${Date.now()}`;
   const res = await fetch(url, { cache: 'no-cache' });
   if (!res.ok) throw new Error(`无法加载文章 ${slug}`);
   return await res.text();

--- a/post.html
+++ b/post.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20170101/index.html
+++ b/post/20170101/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20170606/index.html
+++ b/post/20170606/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20170607/index.html
+++ b/post/20170607/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20170608/index.html
+++ b/post/20170608/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20170609/index.html
+++ b/post/20170609/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20170610/index.html
+++ b/post/20170610/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20170611/index.html
+++ b/post/20170611/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20170612/index.html
+++ b/post/20170612/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20170613/index.html
+++ b/post/20170613/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20170614/index.html
+++ b/post/20170614/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20170617/index.html
+++ b/post/20170617/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20170618/index.html
+++ b/post/20170618/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20170622/index.html
+++ b/post/20170622/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20170705/index.html
+++ b/post/20170705/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20180101/index.html
+++ b/post/20180101/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20180421/index.html
+++ b/post/20180421/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20180423-2/index.html
+++ b/post/20180423-2/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20180423/index.html
+++ b/post/20180423/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20180426/index.html
+++ b/post/20180426/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20180427/index.html
+++ b/post/20180427/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20180501-2/index.html
+++ b/post/20180501-2/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20180501-3/index.html
+++ b/post/20180501-3/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20180501/index.html
+++ b/post/20180501/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20180514/index.html
+++ b/post/20180514/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20180621/index.html
+++ b/post/20180621/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181006/index.html
+++ b/post/20181006/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181007/index.html
+++ b/post/20181007/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181008/index.html
+++ b/post/20181008/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181010/index.html
+++ b/post/20181010/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181013/index.html
+++ b/post/20181013/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181025/index.html
+++ b/post/20181025/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181029/index.html
+++ b/post/20181029/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181030/index.html
+++ b/post/20181030/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181101/index.html
+++ b/post/20181101/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181107/index.html
+++ b/post/20181107/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181111/index.html
+++ b/post/20181111/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181114/index.html
+++ b/post/20181114/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181122/index.html
+++ b/post/20181122/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181123/index.html
+++ b/post/20181123/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181202/index.html
+++ b/post/20181202/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181203/index.html
+++ b/post/20181203/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181206/index.html
+++ b/post/20181206/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181214/index.html
+++ b/post/20181214/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20181216/index.html
+++ b/post/20181216/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20190101-2/index.html
+++ b/post/20190101-2/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20190101/index.html
+++ b/post/20190101/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20190605-2/index.html
+++ b/post/20190605-2/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20190605-3/index.html
+++ b/post/20190605-3/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20190605-4/index.html
+++ b/post/20190605-4/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20190605/index.html
+++ b/post/20190605/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20200101/index.html
+++ b/post/20200101/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20220309/index.html
+++ b/post/20220309/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20220310/index.html
+++ b/post/20220310/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20220311/index.html
+++ b/post/20220311/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20220312/index.html
+++ b/post/20220312/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20220313/index.html
+++ b/post/20220313/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20260311/index.html
+++ b/post/20260311/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/20260415/index.html
+++ b/post/20260415/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/about/index.html
+++ b/post/about/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/post/welcome/index.html
+++ b/post/welcome/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260514200000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // 与 ?v=VERSION 的 cache-busting 协同：CACHE_NAME 用 release VERSION 区分批次
 // ============================================================================
 
-const SW_VERSION = '20260514220000';
+const SW_VERSION = '20260515180000';
 const STATIC_CACHE = `static-${SW_VERSION}`;
 const PAGE_CACHE = `pages-${SW_VERSION}`;
 const RUNTIME_CACHE = `runtime-${SW_VERSION}`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Post URLs:** date-based `/post/YYYYMMDD/` (+ same-day suffix); **`/post/welcome/`**, **`/post/about/`** for fixed slugs.
- **Fix:** `fetchIndexPublic` / `fetchPostMarkdownPublic` in `api.js` no longer use `./data/...` (broken from `/post/.../`). They use root-absolute paths from `CONFIG.site.url` (same as `siteBasePath`), avoiding `site.js` ↔ `api.js` circular imports.

## Verify

From `/post/20220313/`, DevTools should request `GET /data/posts.json` (200), not `/post/20220313/data/posts.json`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

