### PR TITLE
fix: post page index fetch + asset image URLs under /post/

### DIFF
--- a/assets/js/post.js
+++ b/assets/js/post.js
@@ -16,7 +16,19 @@ import { mountGiscusScript } from './giscus-embed.js';
 const $ = sel => document.querySelector(sel);
 
 function publicImageUrl(url) {
-  return String(url || '').replace(/^\.\.\/assets\//, 'assets/');
+  const s = String(url || '').trim();
+  if (!s) return '';
+  if (/^https?:\/\//i.test(s) || s.startsWith('//')) return s;
+  if (s.startsWith('data:') || s.startsWith('blob:')) return s;
+
+  let rel = s.replace(/^\.\//, '');
+  rel = rel.replace(/^\/+/, '');
+  while (rel.startsWith('../')) rel = rel.slice(3);
+
+  if (rel.startsWith('assets/') || rel.startsWith('posts/')) {
+    return rootPath(rel);
+  }
+  return s;
 }
 
 function buildToc(article) {
@@ -166,8 +178,15 @@ function enhanceImages(article) {
 
   article.querySelectorAll('img').forEach(img => {
     const rawSrc = img.getAttribute('src') || '';
-    if (/^\.\.\/assets\//.test(rawSrc)) {
-      img.setAttribute('src', publicImageUrl(rawSrc));
+    if (
+      rawSrc
+      && !/^https?:\/\//i.test(rawSrc)
+      && !rawSrc.startsWith('//')
+      && !rawSrc.startsWith('data:')
+      && !rawSrc.startsWith('blob:')
+    ) {
+      const fixed = publicImageUrl(rawSrc);
+      if (fixed) img.setAttribute('src', fixed);
     }
     // 清除老内容里的固定 width / height（公众号常见 width="600"），让图按容器宽度自适应
     if (img.hasAttribute('width')) img.removeAttribute('width');

--- a/post.html
+++ b/post.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20170101/index.html
+++ b/post/20170101/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20170606/index.html
+++ b/post/20170606/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20170607/index.html
+++ b/post/20170607/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20170608/index.html
+++ b/post/20170608/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20170609/index.html
+++ b/post/20170609/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20170610/index.html
+++ b/post/20170610/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20170611/index.html
+++ b/post/20170611/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20170612/index.html
+++ b/post/20170612/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20170613/index.html
+++ b/post/20170613/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20170614/index.html
+++ b/post/20170614/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20170617/index.html
+++ b/post/20170617/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20170618/index.html
+++ b/post/20170618/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20170622/index.html
+++ b/post/20170622/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20170705/index.html
+++ b/post/20170705/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20180101/index.html
+++ b/post/20180101/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20180421/index.html
+++ b/post/20180421/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20180423-2/index.html
+++ b/post/20180423-2/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20180423/index.html
+++ b/post/20180423/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20180426/index.html
+++ b/post/20180426/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20180427/index.html
+++ b/post/20180427/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20180501-2/index.html
+++ b/post/20180501-2/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20180501-3/index.html
+++ b/post/20180501-3/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20180501/index.html
+++ b/post/20180501/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20180514/index.html
+++ b/post/20180514/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20180621/index.html
+++ b/post/20180621/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181006/index.html
+++ b/post/20181006/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181007/index.html
+++ b/post/20181007/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181008/index.html
+++ b/post/20181008/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181010/index.html
+++ b/post/20181010/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181013/index.html
+++ b/post/20181013/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181025/index.html
+++ b/post/20181025/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181029/index.html
+++ b/post/20181029/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181030/index.html
+++ b/post/20181030/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181101/index.html
+++ b/post/20181101/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181107/index.html
+++ b/post/20181107/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181111/index.html
+++ b/post/20181111/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181114/index.html
+++ b/post/20181114/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181122/index.html
+++ b/post/20181122/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181123/index.html
+++ b/post/20181123/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181202/index.html
+++ b/post/20181202/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181203/index.html
+++ b/post/20181203/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181206/index.html
+++ b/post/20181206/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181214/index.html
+++ b/post/20181214/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20181216/index.html
+++ b/post/20181216/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20190101-2/index.html
+++ b/post/20190101-2/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20190101/index.html
+++ b/post/20190101/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20190605-2/index.html
+++ b/post/20190605-2/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20190605-3/index.html
+++ b/post/20190605-3/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20190605-4/index.html
+++ b/post/20190605-4/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20190605/index.html
+++ b/post/20190605/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20200101/index.html
+++ b/post/20200101/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20220309/index.html
+++ b/post/20220309/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20220310/index.html
+++ b/post/20220310/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20220311/index.html
+++ b/post/20220311/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20220312/index.html
+++ b/post/20220312/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20220313/index.html
+++ b/post/20220313/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20260311/index.html
+++ b/post/20260311/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/20260415/index.html
+++ b/post/20260415/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/about/index.html
+++ b/post/about/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/post/welcome/index.html
+++ b/post/welcome/index.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515180000"></script>
+  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // 与 ?v=VERSION 的 cache-busting 协同：CACHE_NAME 用 release VERSION 区分批次
 // ============================================================================
 
-const SW_VERSION = '20260515180000';
+const SW_VERSION = '20260515190000';
 const STATIC_CACHE = `static-${SW_VERSION}`;
 const PAGE_CACHE = `pages-${SW_VERSION}`;
 const RUNTIME_CACHE = `runtime-${SW_VERSION}`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Fixes

1. **`/post/.../` + `data/posts.json`:** `fetchIndexPublic` / `fetchPostMarkdownPublic` use root-absolute paths (same prefix rule as `siteBasePath`), not `./data/...`.
2. **Images in article body:** Markdown often uses `assets/uploads/...` without `../`. From `/post/urlKey/` the browser resolved that to `/post/assets/...` (404). `publicImageUrl` now normalizes `../` chains and maps `assets/` and `posts/` through `rootPath()`; `enhanceImages` applies this to all non-external `img[src]`.

## Also in branch

Date-based post URLs, `/post/welcome/` & `/post/about/`, notes copy, etc.

## Verify

Open a post with embedded `![](assets/uploads/...)` under `/post/YYYYMMDD/` — images should request `/assets/uploads/...` (or `/repo/assets/...` on project Pages).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

