### PR TITLE
fix(sw): serve sitemap.xml and rss.xml instead of offline fallback

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // 与 ?v=VERSION 的 cache-busting 协同：CACHE_NAME 用 release VERSION 区分批次
 // ============================================================================
 
-const SW_VERSION = '20260515190000';
+const SW_VERSION = '20260515200000';
 const STATIC_CACHE = `static-${SW_VERSION}`;
 const PAGE_CACHE = `pages-${SW_VERSION}`;
 const RUNTIME_CACHE = `runtime-${SW_VERSION}`;
@@ -62,8 +62,17 @@ self.addEventListener('fetch', event => {
   if (!shouldHandle(request)) return;
 
   const url = new URL(request.url);
-  const isHTML = request.mode === 'navigate' ||
-                 (request.headers.get('accept') || '').includes('text/html');
+  const pathname = url.pathname;
+  // 地址栏直接打开 sitemap.xml / rss.xml 时仍是 navigate，且 Accept 常带 text/html，
+  // 不能走 handleHtml，否则无缓存时会落到 offline.html。
+  const isNonHtmlDocument = /\.xml$/i.test(pathname)
+    || /\/robots\.txt$/i.test(pathname)
+    || /\.txt$/i.test(pathname);
+
+  const isHTML = !isNonHtmlDocument && (
+    request.mode === 'navigate'
+    || (request.headers.get('accept') || '').includes('text/html')
+  );
 
   if (isHTML) {
     event.respondWith(handleHtml(request, event));
@@ -71,7 +80,7 @@ self.addEventListener('fetch', event => {
   }
 
   // 静态资源：stale-while-revalidate
-  if (/\.(?:css|js|svg|png|jpg|jpeg|gif|webp|ico|woff2?|ttf|json|xml|webmanifest)$/i.test(url.pathname)) {
+  if (/\.(?:css|js|svg|png|jpg|jpeg|gif|webp|ico|woff2?|ttf|json|xml|txt|webmanifest)$/i.test(pathname)) {
     event.respondWith(
       caches.match(request).then(cached => {
         const network = fetch(request).then(res => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this PR adds (ahead of `main`)

### Service Worker: `sitemap.xml` / `rss.xml` / `robots.txt`

Top-level navigation to `.xml` (and `.txt` / `robots.txt`) was misclassified as HTML because `request.mode === 'navigate'` and `Accept` often includes `text/html`. The SW then ran `handleHtml` and could fall back to `offline.html`.

**Change:** treat those paths as static assets (same stale-while-revalidate branch as CSS/JS/JSON). Bump `SW_VERSION` to `20260515200000`.

### Already on this branch (if not yet on your `main`)

- Date-based post URLs + `/post/welcome/` / `/post/about/`
- `fetchIndexPublic` / `fetchPostMarkdownPublic` root-absolute paths for `/post/.../`
- Article image `src` resolved via `rootPath` for `assets/` and `posts/` paths
- Notes welcome copy, etc.

## Verify

After deploy: open `https://gitpull.cn/sitemap.xml` and `rss.xml` — should return XML, not the offline page (hard-refresh or wait for SW update).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

