### PR TITLE
perf: timeout + absolute URLs for posts.json / search.json fetch

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -161,6 +161,52 @@ function publicAssetAbsPath(relPath) {
   return `${bp}/${r}`.replace(/\/{2,}/g, '/');
 }
 
+/** 浏览器里用「当前 origin + 站点 path 前缀」拉静态 JSON/HTML，避免仅靠相对路径在 SW 下长时间挂起 */
+function publicAssetFetchUrl(relPath) {
+  const path = publicAssetAbsPath(relPath);
+  if (typeof window !== 'undefined' && window.location && window.location.origin && path.startsWith('/')) {
+    try {
+      return new URL(path, window.location.origin).href;
+    } catch {
+      /* 忽略 */
+    }
+  }
+  return `./${String(relPath || '').replace(/^\//, '')}`;
+}
+
+function cacheBust(url) {
+  return `${url}${String(url).includes('?') ? '&' : '?'}t=${Date.now()}`;
+}
+
+async function fetchWithTimeout(url, options = {}, ms = 15000) {
+  const ctrl = new AbortController();
+  const id = setTimeout(() => ctrl.abort(), ms);
+  try {
+    return await fetch(url, { ...options, signal: ctrl.signal });
+  } finally {
+    clearTimeout(id);
+  }
+}
+
+/** 拉取 build 生成的 JSON（绝对 URL + 超时；失败时静默重试一次） */
+export async function fetchStaticJson(relPath, ms = 15000) {
+  const rel = String(relPath || '').replace(/^\//, '');
+  const base = publicAssetFetchUrl(rel);
+  const tryOnce = async () => {
+    try {
+      const res = await fetchWithTimeout(cacheBust(base), { cache: 'no-cache' }, ms);
+      if (!res || !res.ok) return null;
+      return await res.json();
+    } catch {
+      return null;
+    }
+  };
+  let j = await tryOnce();
+  if (j) return j;
+  j = await tryOnce();
+  return j;
+}
+
 // ---------- 文章索引 ----------
 // posts.json 形如：
 // { posts: [ { slug, title, date, summary, tags, author, cover, path } ] }
@@ -179,22 +225,29 @@ export async function readIndex() {
 
 // 用 fetch 直接拿静态文件版本（首页未登录时使用，避免 API 限流）
 export async function fetchIndexPublic() {
-  const url = `${publicAssetAbsPath(CONFIG.paths.index)}?t=${Date.now()}`;
-  try {
-    const res = await fetch(url, { cache: 'no-cache' });
-    if (!res.ok) return { posts: [] };
-    return await res.json();
-  } catch {
-    return { posts: [] };
-  }
+  const j = await fetchStaticJson(CONFIG.paths.index, 15000);
+  if (j && Array.isArray(j.posts)) return j;
+  return { posts: [] };
 }
 
 export async function fetchPostMarkdownPublic(slug) {
   const rel = `${CONFIG.paths.posts}/${encodeURIComponent(slug)}.md`;
-  const url = `${publicAssetAbsPath(rel)}?t=${Date.now()}`;
-  const res = await fetch(url, { cache: 'no-cache' });
-  if (!res.ok) throw new Error(`无法加载文章 ${slug}`);
-  return await res.text();
+  const ms = 20000;
+  const base = publicAssetFetchUrl(rel);
+  const tryText = async () => {
+    try {
+      const res = await fetchWithTimeout(cacheBust(base), { cache: 'no-cache' }, ms);
+      if (!res || !res.ok) return null;
+      return await res.text();
+    } catch {
+      return null;
+    }
+  };
+  let t = await tryText();
+  if (t) return t;
+  t = await tryText();
+  if (t) return t;
+  throw new Error(`无法加载文章 ${slug}`);
 }
 
 // 保存索引

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -5,7 +5,7 @@
 
 import { CONFIG } from './config.js';
 import { initTheme, bindThemeToggle, themeToggleHtml } from './theme.js';
-import { fetchIndexPublic } from './api.js';
+import { fetchIndexPublic, fetchStaticJson } from './api.js';
 import { initPageviews, bszSiteStatsHtml } from './pageviews.js';
 
 const $ = (sel, root = document) => root.querySelector(sel);
@@ -333,13 +333,10 @@ let searchIndexCache = null;
 async function getSearchIndex() {
   if (searchIndexCache) return searchIndexCache;
   try {
-    const r = await fetch('data/search.json?_=' + Date.now(), { cache: 'no-cache' });
-    if (r.ok) {
-      const j = await r.json();
-      if (Array.isArray(j.docs)) {
-        searchIndexCache = j.docs;
-        return searchIndexCache;
-      }
+    const j = await fetchStaticJson('data/search.json', 15000);
+    if (j && Array.isArray(j.docs)) {
+      searchIndexCache = j.docs;
+      return searchIndexCache;
     }
   } catch {}
   searchIndexCache = null;

--- a/index.html
+++ b/index.html
@@ -47,6 +47,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="assets/js/home.js?v=20260515120000"></script>
+  <script type="module" src="assets/js/home.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post.html
+++ b/post.html
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // 与 ?v=VERSION 的 cache-busting 协同：CACHE_NAME 用 release VERSION 区分批次
 // ============================================================================
 
-const SW_VERSION = '20260515200000';
+const SW_VERSION = '20260515210000';
 const STATIC_CACHE = `static-${SW_VERSION}`;
 const PAGE_CACHE = `pages-${SW_VERSION}`;
 const RUNTIME_CACHE = `runtime-${SW_VERSION}`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why the homepage could sit on「加载中…」

1. **`data/posts.json` fetch had no timeout** — if the Service Worker’s network leg or GitHub Pages was slow, the promise could hang for a long time before resolving.
2. **`search.json` used a relative `fetch('data/search.json')`** — from some entry paths this is fragile; it now uses the same **`fetchStaticJson`** helper as the index (absolute URL + timeout).

## What changed

- **`api.js`:** `publicAssetFetchUrl` builds `https://{current host}{/prefix}/data/posts.json`, `fetchWithTimeout`, `fetchStaticJson`, and wired `fetchIndexPublic` / `fetchPostMarkdownPublic` through them (with one silent retry).
- **`site.js`:** `getSearchIndex` uses `fetchStaticJson('data/search.json')`.
- Cache-bust **`index.html`** / **`post.html`** module URLs and **`SW_VERSION`**.

After deploy, worst case the list should unblock within ~15s even on bad networks (then may show empty if the file truly failed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

