### PR TITLE
fix: post shells use absolute /assets paths + SW HTML wait

### DIFF
--- a/post/20170101/index.html
+++ b/post/20170101/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20170606/index.html
+++ b/post/20170606/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20170607/index.html
+++ b/post/20170607/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20170608/index.html
+++ b/post/20170608/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20170609/index.html
+++ b/post/20170609/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20170610/index.html
+++ b/post/20170610/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20170611/index.html
+++ b/post/20170611/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20170612/index.html
+++ b/post/20170612/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20170613/index.html
+++ b/post/20170613/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20170614/index.html
+++ b/post/20170614/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20170617/index.html
+++ b/post/20170617/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20170618/index.html
+++ b/post/20170618/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20170622/index.html
+++ b/post/20170622/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20170705/index.html
+++ b/post/20170705/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20180101/index.html
+++ b/post/20180101/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20180421/index.html
+++ b/post/20180421/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20180423-2/index.html
+++ b/post/20180423-2/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20180423/index.html
+++ b/post/20180423/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20180426/index.html
+++ b/post/20180426/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20180427/index.html
+++ b/post/20180427/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20180501-2/index.html
+++ b/post/20180501-2/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20180501-3/index.html
+++ b/post/20180501-3/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20180501/index.html
+++ b/post/20180501/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20180514/index.html
+++ b/post/20180514/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20180621/index.html
+++ b/post/20180621/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181006/index.html
+++ b/post/20181006/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181007/index.html
+++ b/post/20181007/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181008/index.html
+++ b/post/20181008/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181010/index.html
+++ b/post/20181010/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181013/index.html
+++ b/post/20181013/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181025/index.html
+++ b/post/20181025/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181029/index.html
+++ b/post/20181029/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181030/index.html
+++ b/post/20181030/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181101/index.html
+++ b/post/20181101/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181107/index.html
+++ b/post/20181107/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181111/index.html
+++ b/post/20181111/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181114/index.html
+++ b/post/20181114/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181122/index.html
+++ b/post/20181122/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181123/index.html
+++ b/post/20181123/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181202/index.html
+++ b/post/20181202/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181203/index.html
+++ b/post/20181203/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181206/index.html
+++ b/post/20181206/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181214/index.html
+++ b/post/20181214/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20181216/index.html
+++ b/post/20181216/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20190101-2/index.html
+++ b/post/20190101-2/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20190101/index.html
+++ b/post/20190101/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20190605-2/index.html
+++ b/post/20190605-2/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20190605-3/index.html
+++ b/post/20190605-3/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20190605-4/index.html
+++ b/post/20190605-4/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20190605/index.html
+++ b/post/20190605/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20200101/index.html
+++ b/post/20200101/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20220309/index.html
+++ b/post/20220309/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20220310/index.html
+++ b/post/20220310/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20220311/index.html
+++ b/post/20220311/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20220312/index.html
+++ b/post/20220312/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20220313/index.html
+++ b/post/20220313/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20260311/index.html
+++ b/post/20260311/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/20260415/index.html
+++ b/post/20260415/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/about/index.html
+++ b/post/about/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/post/welcome/index.html
+++ b/post/welcome/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>加载中…</title>
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="../../rss.xml">
-  <link rel="stylesheet" href="../../assets/css/common.css?v=20260514200000">
-  <link rel="stylesheet" href="../../assets/css/post.css?v=20260514200000">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+  <link rel="stylesheet" href="/assets/css/common.css?v=20260514200000">
+  <link rel="stylesheet" href="/assets/css/post.css?v=20260514200000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
-  <link rel="manifest" href="../../manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
-  <link rel="apple-touch-icon" href="../../assets/icon.svg">
+  <link rel="apple-touch-icon" href="/assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
 <body>
@@ -27,6 +27,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="../../assets/js/post.js?v=20260515190000"></script>
+  <script type="module" src="/assets/js/post.js?v=20260515210000"></script>
 </body>
 </html>

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -472,13 +472,21 @@ for (const post of [...visiblePosts, ...pages.filter(p => !p.draft)]) {
 console.log(`OG 分享图已生成：${visiblePosts.length + pages.filter(p => !p.draft).length} 张`);
 
 // ---------- post/{urlKey}/index.html（/post/YYYYMMDD/ 与 post.js 一致） ----------
+/** 壳内 href/src 用站点根绝对路径，避免在 /post/xxx/ 下相对路径变成 /post/xxx/assets/… 或 SW 缓存旧壳错位 */
+function postShellRootHref(relPath) {
+  const p = String(relPath || '').replace(/^\/+/, '');
+  if (!SITE_PATH_PREFIX) return `/${p}`;
+  return `${SITE_PATH_PREFIX.replace(/\/+$/, '')}/${p}`.replace(/\/{2,}/g, '/');
+}
+
 function rewritePostShellHtml(html) {
+  const a = postShellRootHref('assets');
   return html
-    .replace(/\bhref="assets\//g, 'href="../../assets/')
-    .replace(/\bsrc="assets\//g, 'src="../../assets/')
-    .replace(/\bhref="manifest\.webmanifest"/g, 'href="../../manifest.webmanifest"')
-    .replace(/\bhref="rss\.xml"/g, 'href="../../rss.xml"')
-    .replace(/\blink rel="apple-touch-icon" href="assets\//g, 'link rel="apple-touch-icon" href="../../assets/');
+    .replace(/\bhref="assets\//g, `href="${a}/`)
+    .replace(/\bsrc="assets\//g, `src="${a}/`)
+    .replace(/\bhref="manifest\.webmanifest"/g, `href="${postShellRootHref('manifest.webmanifest')}"`)
+    .replace(/\bhref="rss\.xml"/g, `href="${postShellRootHref('rss.xml')}"`)
+    .replace(/\blink rel="apple-touch-icon" href="assets\//g, `link rel="apple-touch-icon" href="${a}/`);
 }
 const POST_SHELL = rewritePostShellHtml(readFileSync('post.html', 'utf8'));
 const POST_ROOT = 'post';

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // 与 ?v=VERSION 的 cache-busting 协同：CACHE_NAME 用 release VERSION 区分批次
 // ============================================================================
 
-const SW_VERSION = '20260515210000';
+const SW_VERSION = '20260515220000';
 const STATIC_CACHE = `static-${SW_VERSION}`;
 const PAGE_CACHE = `pages-${SW_VERSION}`;
 const RUNTIME_CACHE = `runtime-${SW_VERSION}`;
@@ -114,10 +114,10 @@ async function handleHtml(request, event) {
     return cached;
   }
 
-  // 首次访问且没有缓存时才等网络；最多等 2 秒，随后降级到离线页。
+  // 首次访问且没有缓存时才等网络；多等几秒避免慢网/冷启动时误落到离线页
   return Promise.race([
     network.catch(() => null),
-    delay(2000).then(() => null),
+    delay(6000).then(() => null),
   ]).then(res => res || caches.match(OFFLINE_URL));
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What you were seeing (Network tab)

- Document `20220311/` **200 from ServiceWorker** while **CSS / manifest 404** and long hangs usually means the **cached `post/.../index.html` shell** still used **relative** `../../assets/...` links. From some SW/cache states that can resolve to **`/post/.../assets/...`** (wrong) → 404, `post.js` may not run, and the HTML shell’s loading state can linger until the SW **HTML handler** falls through to **`offline.html`** (“当前没有网络”).

## Fix

- **`scripts/build.mjs`:** `rewritePostShellHtml` now writes **root-absolute** `href`/`src` (`/assets/...`, `/manifest.webmanifest`, `/rss.xml`, …) with **`SITE_PATH_PREFIX`** for GitHub Pages project sites (`/repo/assets/...`).
- **`sw.js`:** first navigation **network race** increased **2s → 6s** before offline fallback; **`SW_VERSION`** bumped so clients drop stale shells.

Rebuild regenerates all `post/*/index.html`.

## Verify

Open `/post/20220311/` → Network should request **`/assets/css/common.css`** (200), not under `/post/.../assets/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

