### PR TITLE
fix(home): hero strip avatar-only with aligned bio and stats

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -30,17 +30,6 @@
 .hero-link > .hero-arrow {
   align-self: center;
 }
-
-/* 头像与站点名同一竖列，右侧为简介与统计 */
-.hero-brand {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 10px;
-  flex-shrink: 0;
-  max-width: 9em;
-  text-align: center;
-}
 .hero-arrow {
   flex-shrink: 0;
   font-size: 28px;
@@ -62,16 +51,28 @@
   box-shadow: var(--shadow);
 }
 
-.hero-info { flex: 1; min-width: 0; }
-.hero-title {
-  font-size: 22px;
-  font-weight: 700;
-  margin: 0;
-  line-height: 1.2;
-  word-break: break-word;
+.hero-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 10px;
+  text-align: left;
 }
-.hero-subtitle { font-size: 14px; color: var(--text-secondary); margin-bottom: 14px; line-height: 1.6; }
-.hero-stats { display: flex; gap: 18px; font-size: 13px; color: var(--text-secondary); }
+.hero-subtitle {
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.6;
+}
+.hero-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
 .hero-stats .stat {
   flex: 0 0 auto;
   white-space: nowrap;
@@ -90,12 +91,12 @@
   }
   .hero-link {
     align-items: flex-start;
-    padding: 11px 12px 10px;
+    padding: 9px 12px 9px;
     gap: 10px;
   }
-  .hero-brand {
+  .hero-info {
     gap: 5px;
-    max-width: 5.5rem;
+    padding-right: 22px;
   }
   .hero-arrow {
     position: absolute;
@@ -112,30 +113,22 @@
     margin-top: 0;
     border-width: 2px;
   }
-  .hero-title {
-    font-size: 15px;
-    line-height: 1.2;
-    margin: 0;
-    padding-right: 0;
-  }
   .hero-subtitle {
     font-size: 12px;
     line-height: 1.45;
-    margin-bottom: 7px;
-    padding-right: 16px;
+    margin: 0;
+    padding-right: 0;
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
   }
   .hero-stats {
-    display: flex;
-    flex-wrap: wrap;
     row-gap: 5px;
     column-gap: 5px;
     font-size: 11px;
     line-height: 1;
-    padding-right: 6px;
+    padding-right: 0;
   }
   .hero-stats .stat {
     display: inline-flex;

--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -41,11 +41,8 @@ function renderHero(posts) {
   posts.forEach(p => (p.tags || []).forEach(t => tagCount.add(t)));
   // 整块 hero 包一层 <a> 跳转到「关于」页面：支持点击 / 右键新标签 / 中键新窗口
   hero.innerHTML = `
-    <a class="hero-link" href="${postPath('about')}" aria-label="进入关于页">
-      <div class="hero-brand">
-        <div class="hero-avatar" style="background-image:url(${escapeHtml(CONFIG.site.avatar || '')})"></div>
-        <div class="hero-title">${escapeHtml(CONFIG.site.title)}</div>
-      </div>
+    <a class="hero-link" href="${postPath('about')}" aria-label="关于${escapeHtml(CONFIG.site.title || '本站')}">
+      <div class="hero-avatar" style="background-image:url(${escapeHtml(CONFIG.site.avatar || '')})"></div>
       <div class="hero-info">
         <div class="hero-subtitle">${escapeHtml(CONFIG.site.description || CONFIG.site.subtitle || '')}</div>
         <div class="hero-stats">

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta name="description" content="">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
   <link rel="stylesheet" href="assets/css/common.css?v=20260512184000">
-  <link rel="stylesheet" href="assets/css/home.css?v=20260516133000">
+  <link rel="stylesheet" href="assets/css/home.css?v=20260516140000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
@@ -47,6 +47,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="assets/js/home.js?v=20260516133000"></script>
+  <script type="module" src="assets/js/home.js?v=20260516140000"></script>
 </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Homepage hero: **avatar only** on the left (no duplicate “小红鸡” in the card; the nav still shows the title). Bio line and stat pills use a **flex column + gap** so they align on the left; **`.hero-info` padding-right** on mobile clears the chevron.

## Files

- `assets/js/home.js` — simplified hero markup, accessible `aria-label`
- `assets/css/home.css` — layout / spacing
- `index.html` — cache bust
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

