### PR TITLE
fix(home): prevent hero avatar column from collapsing over text

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -31,21 +31,24 @@
   align-self: center;
 }
 
-/* 拉伸到与右侧内容同高，内层头像保持 1:1 */
+/* 拉伸到与右侧内容同高；用 grid 定宽，避免横向 flex 下 wrap 宽度塌成 0 导致与正文重叠 */
 .hero-avatar-wrap {
   flex-shrink: 0;
   align-self: stretch;
   min-height: 0;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: auto;
+  grid-template-rows: 1fr;
+  justify-items: start;
+  align-items: stretch;
 }
 .hero-avatar {
   box-sizing: border-box;
-  flex: 1 1 0;
-  min-height: 0;
+  grid-column: 1;
+  grid-row: 1;
+  height: 100%;
   width: auto;
   aspect-ratio: 1;
-  align-self: flex-start;
   max-width: none;
   border-radius: 50%;
   background-size: cover;

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta name="description" content="">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
   <link rel="stylesheet" href="assets/css/common.css?v=20260512184000">
-  <link rel="stylesheet" href="assets/css/home.css?v=20260516153000">
+  <link rel="stylesheet" href="assets/css/home.css?v=20260516170000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">


### PR DESCRIPTION
Use a single-track grid on .hero-avatar-wrap so column width follows the square avatar; the previous column flex let min-content width stay 0 and the avatar painted over .hero-info.