### PR TITLE
style(home): hero tagline matches post title size and weight

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -76,10 +76,17 @@
   text-align: left;
 }
 .hero-subtitle {
-  font-size: 14px;
-  color: var(--text-secondary);
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-main);
+  line-height: 1.5;
   margin: 0;
-  line-height: 1.6;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
 }
 .hero-stats {
   display: flex;
@@ -126,14 +133,18 @@
     border-width: 2px;
   }
   .hero-subtitle {
-    font-size: 12px;
+    font-size: 15.5px;
+    font-weight: 700;
+    color: var(--text-main);
     line-height: 1.45;
     margin: 0;
     padding-right: 0;
     display: -webkit-box;
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
     -webkit-box-orient: vertical;
     overflow: hidden;
+    word-break: break-word;
   }
   .hero-stats {
     row-gap: 5px;
@@ -481,6 +492,7 @@
   font-weight: 500;
 }
 
+.post-title {
   font-size: 18px;
   font-weight: 700;
   color: var(--text-main);

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta name="description" content="">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
   <link rel="stylesheet" href="assets/css/common.css?v=20260512184000">
-  <link rel="stylesheet" href="assets/css/home.css?v=20260516170000">
+  <link rel="stylesheet" href="assets/css/home.css?v=20260520120000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hero card tagline (`.hero-subtitle`, e.g. site description / 签名) now uses the **same typography as list item titles** (`.post-title`): **18px / bold** on desktop and **15.5px / bold** on narrow screens, with matching line clamps.

Also restores a **missing `.post-title {` selector** in `home.css` where a block of title rules had become orphaned (invalid CSS).

## Files

- `assets/css/home.css`
- `index.html` (cache-bust `home.css`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

