### PR TITLE
fix(home): JS-measured hero avatar column to stop WebView overlap

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -20,7 +20,7 @@
 /* 让整块 hero 可点击跳转到关于页 */
 .hero-link {
   display: flex;
-  align-items: stretch;
+  align-items: center;
   gap: 26px;
   padding: 32px 24px;
   color: inherit;
@@ -31,25 +31,22 @@
   align-self: center;
 }
 
-/* 拉伸到与右侧内容同高；用 grid 定宽，避免横向 flex 下 wrap 宽度塌成 0 导致与正文重叠 */
+/* 头像占位：默认正方形，实际边长由 home.js 按 .hero-info 高度写入，避免 WebView 下宽度塌成 0 叠字 */
 .hero-avatar-wrap {
-  flex-shrink: 0;
-  align-self: stretch;
-  min-height: 0;
-  display: grid;
-  grid-template-columns: auto;
-  grid-template-rows: 1fr;
-  justify-items: start;
-  align-items: stretch;
+  flex: 0 0 auto;
+  align-self: center;
+  width: 72px;
+  height: 72px;
+  min-width: 48px;
+  min-height: 48px;
+  box-sizing: border-box;
+  display: block;
+  overflow: hidden;
 }
 .hero-avatar {
   box-sizing: border-box;
-  grid-column: 1;
-  grid-row: 1;
+  width: 100%;
   height: 100%;
-  width: auto;
-  aspect-ratio: 1;
-  max-width: none;
   border-radius: 50%;
   background-size: cover;
   background-position: center;
@@ -112,7 +109,7 @@
     box-shadow: 0 8px 22px rgba(234, 111, 90, 0.07);
   }
   .hero-link {
-    align-items: stretch;
+    align-items: center;
     padding: 9px 12px 9px;
     gap: 10px;
   }

--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -59,6 +59,40 @@ function renderHero(posts) {
   `;
 }
 
+/** 头像列占位：部分 WebView 下纯 CSS 宽度会塌成 0，导致正文叠在头像上；按右侧内容高度设正方形边长 */
+let heroAvatarResizeObserver = null;
+let heroAvatarResizeFallbackBound = false;
+
+function bindHeroAvatarSizeSync() {
+  const link = document.querySelector('#hero .hero-link');
+  if (!link) return;
+  const info = link.querySelector('.hero-info');
+  const wrap = link.querySelector('.hero-avatar-wrap');
+  if (!info || !wrap) return;
+
+  const apply = () => {
+    const h = Math.ceil(info.getBoundingClientRect().height);
+    const side = Math.min(160, Math.max(48, h || 72));
+    wrap.style.width = `${side}px`;
+    wrap.style.minWidth = `${side}px`;
+    wrap.style.height = `${side}px`;
+    wrap.style.boxSizing = 'border-box';
+  };
+
+  apply();
+
+  if (typeof ResizeObserver === 'undefined') {
+    if (!heroAvatarResizeFallbackBound) {
+      heroAvatarResizeFallbackBound = true;
+      window.addEventListener('resize', apply, { passive: true });
+    }
+    return;
+  }
+  if (heroAvatarResizeObserver) heroAvatarResizeObserver.disconnect();
+  heroAvatarResizeObserver = new ResizeObserver(() => apply());
+  heroAvatarResizeObserver.observe(info);
+}
+
 function renderCarousel(posts) {
   const root = $('#homeCarousel');
   if (!root) return;
@@ -396,11 +430,15 @@ function buildHomeList({ allPosts, tab, q, tag }) {
   }
 
   renderHero(allPosts);
+  bindHeroAvatarSizeSync();
   renderCarousel(allPosts);
   renderTags(allPosts);
   renderRecent(allPosts);
-  // hero-stats 是渲染完才出现的，重新触发一次（pageviews 内部幂等）
+  // hero-stats 异步插入后高度会变，需重新对齐头像占位
   initPageviews();
+  bindHeroAvatarSizeSync();
+  requestAnimationFrame(() => bindHeroAvatarSizeSync());
+  setTimeout(bindHeroAvatarSizeSync, 120);
 
   let tab = 'latest';
   let activeTag = '';

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta name="description" content="">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
   <link rel="stylesheet" href="assets/css/common.css?v=20260512184000">
-  <link rel="stylesheet" href="assets/css/home.css?v=20260520120000">
+  <link rel="stylesheet" href="assets/css/home.css?v=20260520140000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
@@ -47,6 +47,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="assets/js/home.js?v=20260516160000"></script>
+  <script type="module" src="assets/js/home.js?v=20260520140000"></script>
 </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In some in-app browsers (e.g. WeChat), the hero avatar column could still **collapse to zero width** while the circle painted on top of `.hero-info`, so the tagline and stat pills covered the avatar.

## Fix

- **`bindHeroAvatarSizeSync()`** in `assets/js/home.js`: measure **`.hero-info`** height, set **`.hero-avatar-wrap`** `width` / `height` / `minWidth` to the same value (clamped **48–160px**), so the flex row always reserves a real column.
- **`ResizeObserver`** on `.hero-info` to update when stats / async widgets change height; **rAF + `setTimeout`** after `initPageviews()` for late layout.
- **`home.css`**: drop the fragile grid/aspect-ratio stretch; use a **square block** + **`align-items: center`** on `.hero-link`; avatar fills the wrap.

## Files

- `assets/js/home.js`
- `assets/css/home.css`
- `index.html` (cache bust)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

