### PR TITLE
fix(home): nowrap hero tagline; avatar tracks info height

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -78,12 +78,10 @@
   color: #614e4e;
   line-height: 1.5;
   margin: 0;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
-  -webkit-box-orient: vertical;
+  min-width: 0;
+  white-space: nowrap;
   overflow: hidden;
-  word-break: break-word;
+  text-overflow: ellipsis;
 }
 .hero-stats {
   display: flex;
@@ -136,12 +134,10 @@
     line-height: 1.45;
     margin: 0;
     padding-right: 0;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    line-clamp: 3;
-    -webkit-box-orient: vertical;
+    min-width: 0;
+    white-space: nowrap;
     overflow: hidden;
-    word-break: break-word;
+    text-overflow: ellipsis;
   }
   .hero-stats {
     row-gap: 5px;

--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -59,7 +59,7 @@ function renderHero(posts) {
   `;
 }
 
-/** 头像列占位：部分 WebView 下纯 CSS 宽度会塌成 0，导致正文叠在头像上；按右侧内容高度设正方形边长 */
+/** 防 WebView 占位塌缩：按 .hero-info 总高度设正方形；签名单行不换行后高度随文案与统计区自适应 */
 let heroAvatarResizeObserver = null;
 let heroAvatarResizeFallbackBound = false;
 
@@ -91,6 +91,8 @@ function bindHeroAvatarSizeSync() {
   if (heroAvatarResizeObserver) heroAvatarResizeObserver.disconnect();
   heroAvatarResizeObserver = new ResizeObserver(() => apply());
   heroAvatarResizeObserver.observe(info);
+  const sub = info.querySelector('.hero-subtitle');
+  if (sub) heroAvatarResizeObserver.observe(sub);
 }
 
 function renderCarousel(posts) {

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta name="description" content="">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
   <link rel="stylesheet" href="assets/css/common.css?v=20260512184000">
-  <link rel="stylesheet" href="assets/css/home.css?v=20260520150000">
+  <link rel="stylesheet" href="assets/css/home.css?v=20260521120000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
@@ -47,6 +47,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="assets/js/home.js?v=20260520140000"></script>
+  <script type="module" src="assets/js/home.js?v=20260521120000"></script>
 </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Homepage hero **tagline** (`.hero-subtitle`, e.g. the site signature) is **forced to a single line** with **`white-space: nowrap`**, **`text-overflow: ellipsis`**, and **`min-width: 0`** so it does not wrap while staying layout-safe in flex.

The **avatar square** continues to sync to **`.hero-info` height** via `bindHeroAvatarSizeSync()` (ResizeObserver on `.hero-info` and `.hero-subtitle`), so after the line-clamp removal the avatar size tracks the shorter one-line layout plus stats.

## Files

- `assets/css/home.css`
- `assets/js/home.js` (comment + observe subtitle)
- `index.html` (cache bust `home.css` / `home.js`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

