### PR TITLE
feat(home): fit hero signature on one line by shrinking font (no ellipsis)

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -80,8 +80,7 @@
   margin: 0;
   min-width: 0;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  overflow: visible;
 }
 .hero-stats {
   display: flex;
@@ -136,8 +135,7 @@
     padding-right: 0;
     min-width: 0;
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    overflow: visible;
   }
   .hero-stats {
     row-gap: 5px;

--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -59,9 +59,31 @@ function renderHero(posts) {
   `;
 }
 
-/** 防 WebView 占位塌缩：按 .hero-info 总高度设正方形；签名单行不换行后高度随文案与统计区自适应 */
+/** 签名单行：在可用宽度内通过缩小字号展示全文（无省略号）；再按 .hero-info 总高度设头像正方形 */
 let heroAvatarResizeObserver = null;
 let heroAvatarResizeFallbackBound = false;
+
+function fitHeroSubtitleFont() {
+  const sub = document.querySelector('#hero .hero-subtitle');
+  if (!sub) return;
+  sub.style.fontSize = '';
+  const cw = sub.clientWidth;
+  if (cw < 4) return;
+  const base = parseFloat(getComputedStyle(sub).fontSize);
+  if (!Number.isFinite(base) || base < 1) return;
+  const minPx = 6;
+  if (sub.scrollWidth <= cw) return;
+
+  let lo = minPx;
+  let hi = base;
+  for (let i = 0; i < 40 && hi - lo > 0.2; i += 1) {
+    const mid = (lo + hi) / 2;
+    sub.style.fontSize = `${mid}px`;
+    if (sub.scrollWidth <= cw) lo = mid;
+    else hi = mid;
+  }
+  sub.style.fontSize = `${lo}px`;
+}
 
 function bindHeroAvatarSizeSync() {
   const link = document.querySelector('#hero .hero-link');
@@ -71,6 +93,7 @@ function bindHeroAvatarSizeSync() {
   if (!info || !wrap) return;
 
   const apply = () => {
+    fitHeroSubtitleFont();
     const h = Math.ceil(info.getBoundingClientRect().height);
     const side = Math.min(160, Math.max(48, h || 72));
     wrap.style.width = `${side}px`;
@@ -80,6 +103,9 @@ function bindHeroAvatarSizeSync() {
   };
 
   apply();
+  if (document.fonts && document.fonts.ready) {
+    document.fonts.ready.then(() => apply());
+  }
 
   if (typeof ResizeObserver === 'undefined') {
     if (!heroAvatarResizeFallbackBound) {

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta name="description" content="">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
   <link rel="stylesheet" href="assets/css/common.css?v=20260512184000">
-  <link rel="stylesheet" href="assets/css/home.css?v=20260521120000">
+  <link rel="stylesheet" href="assets/css/home.css?v=20260521140000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
@@ -47,6 +47,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="assets/js/home.js?v=20260521120000"></script>
+  <script type="module" src="assets/js/home.js?v=20260521140000"></script>
 </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hero signature (`.hero-subtitle`) stays **one line** with **no ellipsis**. When the text is wider than the available column, **`fitHeroSubtitleFont()`** binary-searches an inline `font-size` down to **6px** so the full string fits, then **`bindHeroAvatarSizeSync()`** re-measures `.hero-info` and updates the square avatar.

- **`document.fonts.ready`** triggers a second pass so webfont metrics are correct.
- **CSS**: removed `text-overflow: ellipsis` / `overflow: hidden`; use **`overflow: visible`** (`.hero` already clips the card).
- **`index.html`**: cache-bust `home.css` / `home.js`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

