### PR TITLE
perf(home): idle prefetch key pages after home render

### DIFF
--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -4,7 +4,7 @@
 
 import { CONFIG } from './config.js';
 import { fetchIndexPublic } from './api.js';
-import { initSite, escapeHtml, fmtDate, timeAgo, tagHtml, bindLazyImages, LAZY_PLACEHOLDER, postPathFromPost, postPath } from './site.js';
+import { initSite, escapeHtml, fmtDate, timeAgo, tagHtml, bindLazyImages, LAZY_PLACEHOLDER, postPathFromPost, postPath, rootPath } from './site.js';
 import { initPageviews, bszSiteStatsHtml } from './pageviews.js';
 import { setMeta, setJsonLd } from './seo.js';
 import { isGiscusReady, mountGiscusScript, notesFeedTerm } from './giscus-embed.js';
@@ -27,6 +27,44 @@ function scheduleRestoreHomeScroll(y) {
   requestAnimationFrame(() => requestAnimationFrame(apply));
   setTimeout(apply, 80);
   setTimeout(apply, 320);
+}
+
+/** 首页首屏就绪后，空闲时预取主要站内页与 posts.json（HTTP 缓存，加速后续导航） */
+function schedulePrefetchOtherPages() {
+  if (typeof document === 'undefined' || !document.head) return;
+  if (navigator.connection && navigator.connection.saveData) return;
+
+  const add = (() => {
+    const seen = new Set();
+    return href => {
+      if (!href || seen.has(href)) return;
+      seen.add(href);
+      let abs;
+      try {
+        abs = new URL(href, window.location.origin);
+      } catch {
+        return;
+      }
+      if (abs.origin !== window.location.origin) return;
+      const link = document.createElement('link');
+      link.rel = 'prefetch';
+      link.href = abs.href;
+      document.head.appendChild(link);
+    };
+  })();
+
+  const inject = () => {
+    ['tags.html', 'archives.html', 'series.html', 'notes.html', 'post.html', 'tools.html'].forEach(p => add(rootPath(p)));
+    const idx = CONFIG.paths && CONFIG.paths.index ? String(CONFIG.paths.index).replace(/^\//, '') : 'data/posts.json';
+    add(rootPath(idx));
+  };
+
+  const ric = window.requestIdleCallback;
+  if (typeof ric === 'function') {
+    ric(() => inject(), { timeout: 4000 });
+  } else {
+    setTimeout(inject, 2200);
+  }
 }
 
 function publicImageUrl(url) {
@@ -555,4 +593,5 @@ function buildHomeList({ allPosts, tab, q, tag }) {
   });
 
   refresh();
+  schedulePrefetchOtherPages();
 })();

--- a/index.html
+++ b/index.html
@@ -47,6 +47,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="assets/js/home.js?v=20260521140000"></script>
+  <script type="module" src="assets/js/home.js?v=20260521190000"></script>
 </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After the homepage finishes its first `refresh()` (posts loaded + list rendered), **`schedulePrefetchOtherPages()`** runs on **`requestIdleCallback`** (fallback `setTimeout(2200)`), injecting **`<link rel="prefetch">`** for:

- `tags.html`, `archives.html`, `series.html`, `notes.html`, `post.html`, `tools.html` (via `rootPath()` so GitHub Pages base paths work)
- `CONFIG.paths.index` (default `data/posts.json`)

**`navigator.connection.saveData`** skips prefetch to respect metered / save-data users.

Prefetch warms the HTTP cache for the next in-site navigation; it does not execute those pages’ scripts until the user actually visits them.

## Files

- `assets/js/home.js`
- `index.html` (cache-bust `home.js`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

