### PR TITLE
perf(home): aggressive preload/modulepreload from page HTML shells

### DIFF
--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -29,41 +29,97 @@ function scheduleRestoreHomeScroll(y) {
   setTimeout(apply, 320);
 }
 
-/** 首页首屏就绪后，空闲时预取主要站内页与 posts.json（HTTP 缓存，加速后续导航） */
+/** 首页首屏就绪后：空闲时 prefetch 主要 HTML + posts.json，再解析各页 HTML 做 preload / modulepreload（与页面内 ?v= 自动对齐） */
 function schedulePrefetchOtherPages() {
   if (typeof document === 'undefined' || !document.head) return;
   if (navigator.connection && navigator.connection.saveData) return;
 
-  const add = (() => {
-    const seen = new Set();
-    return href => {
-      if (!href || seen.has(href)) return;
-      seen.add(href);
-      let abs;
-      try {
-        abs = new URL(href, window.location.origin);
-      } catch {
-        return;
-      }
-      if (abs.origin !== window.location.origin) return;
-      const link = document.createElement('link');
-      link.rel = 'prefetch';
-      link.href = abs.href;
-      document.head.appendChild(link);
-    };
-  })();
+  const basePage = window.location.href;
+  const prefetched = new Set();
+  const preloaded = new Set();
 
-  const inject = () => {
-    ['tags.html', 'archives.html', 'series.html', 'notes.html', 'post.html', 'tools.html'].forEach(p => add(rootPath(p)));
+  function toAbs(href, base = basePage) {
+    if (!href) return '';
+    try {
+      const u = new URL(href, base);
+      if (u.origin !== window.location.origin) return '';
+      return u.href;
+    } catch {
+      return '';
+    }
+  }
+
+  function addPrefetch(href) {
+    const abs = toAbs(href);
+    if (!abs || prefetched.has(abs)) return;
+    prefetched.add(abs);
+    const link = document.createElement('link');
+    link.rel = 'prefetch';
+    link.href = abs;
+    document.head.appendChild(link);
+  }
+
+  function addPreloadStyle(href) {
+    const abs = toAbs(href);
+    if (!abs || preloaded.has(abs)) return;
+    if ([...document.querySelectorAll('link[rel~="stylesheet"]')].some(l => l.href === abs)) return;
+    preloaded.add(abs);
+    const link = document.createElement('link');
+    link.rel = 'preload';
+    link.href = abs;
+    link.as = 'style';
+    document.head.appendChild(link);
+  }
+
+  function addModulePreload(href) {
+    const abs = toAbs(href);
+    if (!abs || preloaded.has(abs)) return;
+    if ([...document.querySelectorAll('script[type="module"]')].some(s => s.src === abs)) return;
+    preloaded.add(abs);
+    const link = document.createElement('link');
+    link.rel = 'modulepreload';
+    link.href = abs;
+    document.head.appendChild(link);
+  }
+
+  async function preloadSubresourcesFromPageHtml(pathRel) {
+    const pageUrl = toAbs(rootPath(pathRel));
+    if (!pageUrl) return;
+    try {
+      const res = await fetch(pageUrl, { credentials: 'same-origin' });
+      if (!res.ok) return;
+      const html = await res.text();
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      doc.querySelectorAll('link[rel="stylesheet"][href], link[rel=stylesheet][href]').forEach(el => {
+        const h = el.getAttribute('href');
+        const abs = toAbs(h, pageUrl);
+        if (abs) addPreloadStyle(abs);
+      });
+      doc.querySelectorAll('script[type="module"][src]').forEach(el => {
+        const s = el.getAttribute('src');
+        const abs = toAbs(s, pageUrl);
+        if (abs) addModulePreload(abs);
+      });
+    } catch {
+      /* 忽略单页失败 */
+    }
+  }
+
+  const run = async () => {
+    const pages = ['tags.html', 'archives.html', 'series.html', 'notes.html', 'post.html', 'tools.html'];
+    pages.forEach(p => addPrefetch(rootPath(p)));
     const idx = CONFIG.paths && CONFIG.paths.index ? String(CONFIG.paths.index).replace(/^\//, '') : 'data/posts.json';
-    add(rootPath(idx));
+    addPrefetch(rootPath(idx));
+    for (const p of pages) {
+      await preloadSubresourcesFromPageHtml(p);
+    }
   };
 
   const ric = window.requestIdleCallback;
   if (typeof ric === 'function') {
-    ric(() => inject(), { timeout: 4000 });
+    ric(() => { run().catch(() => {}); }, { timeout: 6000 });
   } else {
-    setTimeout(inject, 2200);
+    setTimeout(() => { run().catch(() => {}); }, 2200);
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -47,6 +47,6 @@
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
 
-  <script type="module" src="assets/js/home.js?v=20260521190000"></script>
+  <script type="module" src="assets/js/home.js?v=20260521200000"></script>
 </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends homepage idle prefetch:

1. **`rel=prefetch`** — same as before: `tags.html`, `archives.html`, `series.html`, `notes.html`, `post.html`, `tools.html`, and `data/posts.json`.

2. **Aggressive phase** — sequentially `fetch` each of those HTML shells (usually hits the prefetch cache), **`DOMParser`** extracts:
   - every `link[rel=stylesheet][href]` → **`rel=preload` `as=style`**
   - every `script[type=module"][src]` → **`rel=modulepreload`**

   URLs are resolved with `new URL(href, pageUrl)` so **`?v=` stays in sync** with each shell file—no manual version constants.

3. **Deduping / skips**
   - Separate sets for prefetched vs preloaded absolute URLs.
   - Skip `preload` for stylesheets whose **`href` already matches** a stylesheet on the current (home) document.
   - Skip `modulepreload` if a module script with the same **`src`** is already on the page.

4. **`Save-Data`** still disables the whole block; idle **`timeout` raised to 6s** to allow the extra fetches.

## Files

- `assets/js/home.js`
- `index.html` (cache-bust `home.js`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ec23d2-d5a3-45a3-9bb3-cc34bf678e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

