### PR TITLE
style: 文章页 .article-body 字号统一为 16px

### DIFF
--- a/assets/css/post.css
+++ b/assets/css/post.css
@@ -316,11 +316,11 @@
   .article-author .meta { font-size: 11.5px; gap: 6px; }
   .article-edit { font-size: 11px; padding: 3px 10px; }
 
-  .article-body { font-size: 15.5px; line-height: 1.85; }
+  .article-body { font-size: 16px; line-height: 1.85; }
   .article-body h1 { font-size: 22px; }
   .article-body h2 { font-size: 19px; }
   .article-body h3 { font-size: 17px; }
-  .article-body h4 { font-size: 15.5px; }
+  .article-body h4 { font-size: 16px; }
   .article-body pre { padding: 12px 14px; font-size: 12.5px; }
   .article-body blockquote { padding: 8px 14px; font-size: 14px; }
   .article-body table { font-size: 13px; }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
将文章页 `.article-body` 正文字号统一为 16px。

## 变更

- 桌面端原本已是 16px，保持不变
- 移动端（`max-width: 720px`）原先缩小为 15.5px，现改为 16px
- 同步调整移动端 `h4` 标题字号为 16px，与正文一致
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7adec158-4501-474b-9753-7a7818c87603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7adec158-4501-474b-9753-7a7818c87603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

