### PR TITLE
fix: 微信朋友圈分享显示文章封面图

### DIFF
--- a/assets/js/post.js
+++ b/assets/js/post.js
@@ -31,6 +31,14 @@ function publicImageUrl(url) {
   return s;
 }
 
+function absolutePublicImageUrl(url) {
+  const path = publicImageUrl(url);
+  if (!path) return '';
+  if (/^https?:\/\//i.test(path) || path.startsWith('//')) return path;
+  const origin = String(CONFIG.site.url || '').replace(/\/+$/, '');
+  return origin ? `${origin}${path.startsWith('/') ? path : `/${path}`}` : path;
+}
+
 function buildToc(article) {
   const headings = [...article.querySelectorAll('h2, h3')];
   if (headings.length < 2) return null;
@@ -537,7 +545,7 @@ async function enhancePostArticle(article, { slug, title, tags, allPosts, meta, 
   const updated = (meta && meta.updated) || data.updated || date;
   const author = (meta && meta.author) || data.author || CONFIG.site.author;
   const avatar = (meta && meta.avatar) || CONFIG.site.avatar;
-  const cover = publicImageUrl((meta && meta.cover) || data.cover || '');
+  const coverAbs = absolutePublicImageUrl((meta && meta.cover) || data.cover || '');
   const tags = (meta && meta.tags) || data.tags || [];
   const summary = (meta && meta.summary) || data.summary || '';
   // SEO + 优先用 OG 自动图（assets/og/{slug}.svg）兜底
@@ -547,10 +555,11 @@ async function enhancePostArticle(article, { slug, title, tags, allPosts, meta, 
     ? postPath(meta.urlKey)
     : `${rootPath('post.html')}?slug=${encodeURIComponent(slug)}`;
   const canonical = baseSite ? `${baseSite}${canonPathRel}` : `${window.location.origin}${canonPathRel}`;
+  const ogImage = coverAbs || (CONFIG.site.url ? ogAuto : avatar);
   setMeta({
     title,
     description: summary,
-    image: cover || (CONFIG.site.url ? ogAuto : avatar),
+    image: ogImage,
     type: 'article',
     publishedTime: date,
     modifiedTime: updated,
@@ -564,7 +573,7 @@ async function enhancePostArticle(article, { slug, title, tags, allPosts, meta, 
     '@type': 'BlogPosting',
     headline: title,
     description: summary,
-    image: cover || (CONFIG.site.url ? ogAuto : avatar),
+    image: ogImage,
     datePublished: date,
     dateModified: updated,
     author: { '@type': 'Person', name: author || CONFIG.site.author },

--- a/post/20170101/index.html
+++ b/post/20170101/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="用python做一个C类编译器——语法翻译器">
   <meta property="og:description" content="编程语言:Python 3.7 项目地址：python做编译器——语法翻译器 编程平台:manjaro 编程环境:vscode 完成的内容:承接上次的词法分析器，将其输出的字符表转…">
-  <meta property="og:image" content="/assets/uploads/2026/05/用python做一个C类编译器——语法翻译器-15995704-01.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/用python做一个C类编译器——语法翻译器-15995704-01.png">
   <meta property="og:url" content="https://gitpull.cn/post/20170101/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,14 +27,14 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="用python做一个C类编译器——语法翻译器">
   <meta name="twitter:description" content="编程语言:Python 3.7 项目地址：python做编译器——语法翻译器 编程平台:manjaro 编程环境:vscode 完成的内容:承接上次的词法分析器，将其输出的字符表转…">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/用python做一个C类编译器——语法翻译器-15995704-01.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/用python做一个C类编译器——语法翻译器-15995704-01.png">
   <link rel="canonical" href="https://gitpull.cn/post/20170101/">
   <meta property="og:image:width" content="554">
   <meta property="og:image:height" content="654">
   <meta property="article:published_time" content="2017-01-01T00:00:00+08:00">
   <meta property="article:modified_time" content="2022-03-11T23:01:00+08:00">
   <meta property="article:author" content="兰州小红鸡">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"用python做一个C类编译器——语法翻译器","description":"编程语言:Python 3.7 项目地址：python做编译器——语法翻译器 编程平台:manjaro 编程环境:vscode 完成的内容:承接上次的词法分析器，将其输出的字符表转…","image":"/assets/uploads/2026/05/用python做一个C类编译器——语法翻译器-15995704-01.png","datePublished":"2017-01-01T00:00:00+08:00","dateModified":"2022-03-11T23:01:00+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20170101/"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"用python做一个C类编译器——语法翻译器","description":"编程语言:Python 3.7 项目地址：python做编译器——语法翻译器 编程平台:manjaro 编程环境:vscode 完成的内容:承接上次的词法分析器，将其输出的字符表转…","image":"https://gitpull.cn/assets/uploads/2026/05/用python做一个C类编译器——语法翻译器-15995704-01.png","datePublished":"2017-01-01T00:00:00+08:00","dateModified":"2022-03-11T23:01:00+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20170101/"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"用python做一个C类编译器——语法翻译器","item":"https://gitpull.cn/post/20170101/"}]}</script>
 </head>
 <body>

--- a/post/20180101/index.html
+++ b/post/20180101/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="Flybook-用node.js从零开始搭一个简约而不简单的博客站点">
   <meta property="og:description" content="前言：玩了快一年博客了，一直用的第三方框架，比如WordPress，typecho，hexo等。其中hexo用的最久，期间把nex主题改得乱七八糟。上周看完node的文档后，决定自…">
-  <meta property="og:image" content="/assets/uploads/2026/05/Flybook-用node.js从零开始搭一个简约而不简单的博客站点-15995676-01.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/Flybook-用node.js从零开始搭一个简约而不简单的博客站点-15995676-01.png">
   <meta property="og:url" content="https://gitpull.cn/post/20180101/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Flybook-用node.js从零开始搭一个简约而不简单的博客站点">
   <meta name="twitter:description" content="前言：玩了快一年博客了，一直用的第三方框架，比如WordPress，typecho，hexo等。其中hexo用的最久，期间把nex主题改得乱七八糟。上周看完node的文档后，决定自…">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/Flybook-用node.js从零开始搭一个简约而不简单的博客站点-15995676-01.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/Flybook-用node.js从零开始搭一个简约而不简单的博客站点-15995676-01.png">
   <link rel="canonical" href="https://gitpull.cn/post/20180101/">
   <meta property="og:image:width" content="1920">
   <meta property="og:image:height" content="1920">
@@ -35,7 +35,7 @@
   <meta property="article:modified_time" content="2022-03-11T22:50:00+08:00">
   <meta property="article:author" content="兰州小红鸡">
   <meta property="article:tag" content="杂七杂八">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Flybook-用node.js从零开始搭一个简约而不简单的博客站点","description":"前言：玩了快一年博客了，一直用的第三方框架，比如WordPress，typecho，hexo等。其中hexo用的最久，期间把nex主题改得乱七八糟。上周看完node的文档后，决定自…","image":"/assets/uploads/2026/05/Flybook-用node.js从零开始搭一个简约而不简单的博客站点-15995676-01.png","datePublished":"2018-01-01T00:00:00+08:00","dateModified":"2022-03-11T22:50:00+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20180101/","keywords":"杂七杂八"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Flybook-用node.js从零开始搭一个简约而不简单的博客站点","description":"前言：玩了快一年博客了，一直用的第三方框架，比如WordPress，typecho，hexo等。其中hexo用的最久，期间把nex主题改得乱七八糟。上周看完node的文档后，决定自…","image":"https://gitpull.cn/assets/uploads/2026/05/Flybook-用node.js从零开始搭一个简约而不简单的博客站点-15995676-01.png","datePublished":"2018-01-01T00:00:00+08:00","dateModified":"2022-03-11T22:50:00+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20180101/","keywords":"杂七杂八"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"杂七杂八","item":"https://gitpull.cn/tags.html#%E6%9D%82%E4%B8%83%E6%9D%82%E5%85%AB"},{"@type":"ListItem","position":3,"name":"Flybook-用node.js从零开始搭一个简约而不简单的博客站点","item":"https://gitpull.cn/post/20180101/"}]}</script>
 </head>
 <body>

--- a/post/20181006/index.html
+++ b/post/20181006/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="MarkDown的用法学习笔记">
   <meta property="og:description" content="标题 一级标题 ¶二级标题 ¶三级标题 ¶四级标题 ¶五级标题 ¶六级标题 列表 无序列表用 \\ 1. 有序列表用 1. 2. 3. 引用 只需要在文本前加入 这种尖括号（大于号）…">
-  <meta property="og:image" content="/assets/uploads/2026/05/MarkDown的用法学习笔记-93e22221-02.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/MarkDown的用法学习笔记-93e22221-02.png">
   <meta property="og:url" content="https://gitpull.cn/post/20181006/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="MarkDown的用法学习笔记">
   <meta name="twitter:description" content="标题 一级标题 ¶二级标题 ¶三级标题 ¶四级标题 ¶五级标题 ¶六级标题 列表 无序列表用 \\ 1. 有序列表用 1. 2. 3. 引用 只需要在文本前加入 这种尖括号（大于号）…">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/MarkDown的用法学习笔记-93e22221-02.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/MarkDown的用法学习笔记-93e22221-02.png">
   <link rel="canonical" href="https://gitpull.cn/post/20181006/">
   <meta property="og:image:width" content="1041">
   <meta property="og:image:height" content="461">
@@ -35,7 +35,7 @@
   <meta property="article:modified_time" content="2018-11-16T13:12:16+08:00">
   <meta property="article:author" content="兰州小红鸡">
   <meta property="article:tag" content="前端">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"MarkDown的用法学习笔记","description":"标题 一级标题 ¶二级标题 ¶三级标题 ¶四级标题 ¶五级标题 ¶六级标题 列表 无序列表用 \\\\ 1. 有序列表用 1. 2. 3. 引用 只需要在文本前加入 这种尖括号（大于号）…","image":"/assets/uploads/2026/05/MarkDown的用法学习笔记-93e22221-02.png","datePublished":"2018-10-06T13:12:16+08:00","dateModified":"2018-11-16T13:12:16+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181006/","keywords":"前端"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"MarkDown的用法学习笔记","description":"标题 一级标题 ¶二级标题 ¶三级标题 ¶四级标题 ¶五级标题 ¶六级标题 列表 无序列表用 \\\\ 1. 有序列表用 1. 2. 3. 引用 只需要在文本前加入 这种尖括号（大于号）…","image":"https://gitpull.cn/assets/uploads/2026/05/MarkDown的用法学习笔记-93e22221-02.png","datePublished":"2018-10-06T13:12:16+08:00","dateModified":"2018-11-16T13:12:16+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181006/","keywords":"前端"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"前端","item":"https://gitpull.cn/tags.html#%E5%89%8D%E7%AB%AF"},{"@type":"ListItem","position":3,"name":"MarkDown的用法学习笔记","item":"https://gitpull.cn/post/20181006/"}]}</script>
 </head>
 <body>

--- a/post/20181010/index.html
+++ b/post/20181010/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="hexo博客搭建以及next美化教程">
   <meta property="og:description" content="¶前言 本文虽然是非常详细的小白教程 但是也需要一点点的姿势，额，知识储量 ¶知识储量 了解css和html，会写一点html基础语句 用过GitHub，知道建仓库过程以及在命令行…">
-  <meta property="og:image" content="/assets/uploads/2026/05/hexo博客搭建以及next美化教程-e8d13fc-04.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/hexo博客搭建以及next美化教程-e8d13fc-04.png">
   <meta property="og:url" content="https://gitpull.cn/post/20181010/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="hexo博客搭建以及next美化教程">
   <meta name="twitter:description" content="¶前言 本文虽然是非常详细的小白教程 但是也需要一点点的姿势，额，知识储量 ¶知识储量 了解css和html，会写一点html基础语句 用过GitHub，知道建仓库过程以及在命令行…">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/hexo博客搭建以及next美化教程-e8d13fc-04.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/hexo博客搭建以及next美化教程-e8d13fc-04.png">
   <link rel="canonical" href="https://gitpull.cn/post/20181010/">
   <meta property="og:image:width" content="1916">
   <meta property="og:image:height" content="908">
@@ -36,7 +36,7 @@
   <meta property="article:author" content="兰州小红鸡">
   <meta property="article:tag" content="教程">
   <meta property="article:tag" content="博客建站">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"hexo博客搭建以及next美化教程","description":"¶前言 本文虽然是非常详细的小白教程 但是也需要一点点的姿势，额，知识储量 ¶知识储量 了解css和html，会写一点html基础语句 用过GitHub，知道建仓库过程以及在命令行…","image":"/assets/uploads/2026/05/hexo博客搭建以及next美化教程-e8d13fc-04.png","datePublished":"2018-10-10T08:41:50+08:00","dateModified":"2018-11-07T08:41:50+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181010/","keywords":"教程,博客建站"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"hexo博客搭建以及next美化教程","description":"¶前言 本文虽然是非常详细的小白教程 但是也需要一点点的姿势，额，知识储量 ¶知识储量 了解css和html，会写一点html基础语句 用过GitHub，知道建仓库过程以及在命令行…","image":"https://gitpull.cn/assets/uploads/2026/05/hexo博客搭建以及next美化教程-e8d13fc-04.png","datePublished":"2018-10-10T08:41:50+08:00","dateModified":"2018-11-07T08:41:50+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181010/","keywords":"教程,博客建站"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"教程","item":"https://gitpull.cn/tags.html#%E6%95%99%E7%A8%8B"},{"@type":"ListItem","position":3,"name":"hexo博客搭建以及next美化教程","item":"https://gitpull.cn/post/20181010/"}]}</script>
 </head>
 <body>

--- a/post/20181025/index.html
+++ b/post/20181025/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="服务端搭建ssr教程">
   <meta property="og:description" content="教程很简单，整个教程分三步： 第一步：购买VPS服务器 第二步：一键部署VPS服务器 第三步：一键加速VPS服务器 （谷歌BBR加速；对速度要求不高的话，此步骤可省略） ¶第一步：…">
-  <meta property="og:image" content="/assets/uploads/2026/05/服务端搭建ssr教程-651cfd47-01.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/服务端搭建ssr教程-651cfd47-01.png">
   <meta property="og:url" content="https://gitpull.cn/post/20181025/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="服务端搭建ssr教程">
   <meta name="twitter:description" content="教程很简单，整个教程分三步： 第一步：购买VPS服务器 第二步：一键部署VPS服务器 第三步：一键加速VPS服务器 （谷歌BBR加速；对速度要求不高的话，此步骤可省略） ¶第一步：…">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/服务端搭建ssr教程-651cfd47-01.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/服务端搭建ssr教程-651cfd47-01.png">
   <link rel="canonical" href="https://gitpull.cn/post/20181025/">
   <meta property="og:image:width" content="1086">
   <meta property="og:image:height" content="604">
@@ -36,7 +36,7 @@
   <meta property="article:author" content="兰州小红鸡">
   <meta property="article:tag" content="教程">
   <meta property="article:tag" content="前端">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"服务端搭建ssr教程","description":"教程很简单，整个教程分三步： 第一步：购买VPS服务器 第二步：一键部署VPS服务器 第三步：一键加速VPS服务器 （谷歌BBR加速；对速度要求不高的话，此步骤可省略） ¶第一步：…","image":"/assets/uploads/2026/05/服务端搭建ssr教程-651cfd47-01.png","datePublished":"2018-10-25T21:32:17+08:00","dateModified":"2018-11-05T21:32:17+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181025/","keywords":"教程,前端"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"服务端搭建ssr教程","description":"教程很简单，整个教程分三步： 第一步：购买VPS服务器 第二步：一键部署VPS服务器 第三步：一键加速VPS服务器 （谷歌BBR加速；对速度要求不高的话，此步骤可省略） ¶第一步：…","image":"https://gitpull.cn/assets/uploads/2026/05/服务端搭建ssr教程-651cfd47-01.png","datePublished":"2018-10-25T21:32:17+08:00","dateModified":"2018-11-05T21:32:17+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181025/","keywords":"教程,前端"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"教程","item":"https://gitpull.cn/tags.html#%E6%95%99%E7%A8%8B"},{"@type":"ListItem","position":3,"name":"服务端搭建ssr教程","item":"https://gitpull.cn/post/20181025/"}]}</script>
 </head>
 <body>

--- a/post/20181029/index.html
+++ b/post/20181029/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="手动修改博客css样式，打造属于自己的博客样式">
   <meta property="og:description" content="这两天花了点时间修改了下自己的next主题的博客 样式表放在了GitHub上喜欢的话可以直接使用 next博客主题样式修改 使用方法 直接下载样式表，然后复制到自己主题的theme…">
-  <meta property="og:image" content="/assets/uploads/2026/05/手动修改博客css样式打造属于自己的博客样式-e17f6e4c-06.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/手动修改博客css样式打造属于自己的博客样式-e17f6e4c-06.png">
   <meta property="og:url" content="https://gitpull.cn/post/20181029/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="手动修改博客css样式，打造属于自己的博客样式">
   <meta name="twitter:description" content="这两天花了点时间修改了下自己的next主题的博客 样式表放在了GitHub上喜欢的话可以直接使用 next博客主题样式修改 使用方法 直接下载样式表，然后复制到自己主题的theme…">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/手动修改博客css样式打造属于自己的博客样式-e17f6e4c-06.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/手动修改博客css样式打造属于自己的博客样式-e17f6e4c-06.png">
   <link rel="canonical" href="https://gitpull.cn/post/20181029/">
   <meta property="og:image:width" content="1920">
   <meta property="og:image:height" content="1030">
@@ -36,7 +36,7 @@
   <meta property="article:author" content="兰州小红鸡">
   <meta property="article:tag" content="教程">
   <meta property="article:tag" content="博客建站">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"手动修改博客css样式，打造属于自己的博客样式","description":"这两天花了点时间修改了下自己的next主题的博客 样式表放在了GitHub上喜欢的话可以直接使用 next博客主题样式修改 使用方法 直接下载样式表，然后复制到自己主题的theme…","image":"/assets/uploads/2026/05/手动修改博客css样式打造属于自己的博客样式-e17f6e4c-06.png","datePublished":"2018-10-29T06:39:31+08:00","dateModified":"2018-11-04T06:39:31+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181029/","keywords":"教程,博客建站"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"手动修改博客css样式，打造属于自己的博客样式","description":"这两天花了点时间修改了下自己的next主题的博客 样式表放在了GitHub上喜欢的话可以直接使用 next博客主题样式修改 使用方法 直接下载样式表，然后复制到自己主题的theme…","image":"https://gitpull.cn/assets/uploads/2026/05/手动修改博客css样式打造属于自己的博客样式-e17f6e4c-06.png","datePublished":"2018-10-29T06:39:31+08:00","dateModified":"2018-11-04T06:39:31+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181029/","keywords":"教程,博客建站"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"教程","item":"https://gitpull.cn/tags.html#%E6%95%99%E7%A8%8B"},{"@type":"ListItem","position":3,"name":"手动修改博客css样式，打造属于自己的博客样式","item":"https://gitpull.cn/post/20181029/"}]}</script>
 </head>
 <body>

--- a/post/20181101/index.html
+++ b/post/20181101/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="用回valine评论系统,valine评论框样式美化">
   <meta property="og:description" content="我感觉我一个处女座的就不应该搞前端，太吹毛求疵追求完美了，哪里有一点点觉得不漂亮就想改 博客的评论系统用过好几家（虽然都没有人评论 比如gitalk，来必力 之前用的来必力，加载慢…">
-  <meta property="og:image" content="/assets/uploads/2026/05/用回valine评论系统valine评论框样式美化-2d5da13e-01.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/用回valine评论系统valine评论框样式美化-2d5da13e-01.png">
   <meta property="og:url" content="https://gitpull.cn/post/20181101/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="用回valine评论系统,valine评论框样式美化">
   <meta name="twitter:description" content="我感觉我一个处女座的就不应该搞前端，太吹毛求疵追求完美了，哪里有一点点觉得不漂亮就想改 博客的评论系统用过好几家（虽然都没有人评论 比如gitalk，来必力 之前用的来必力，加载慢…">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/用回valine评论系统valine评论框样式美化-2d5da13e-01.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/用回valine评论系统valine评论框样式美化-2d5da13e-01.png">
   <link rel="canonical" href="https://gitpull.cn/post/20181101/">
   <meta property="og:image:width" content="922">
   <meta property="og:image:height" content="379">
@@ -36,7 +36,7 @@
   <meta property="article:author" content="兰州小红鸡">
   <meta property="article:tag" content="教程">
   <meta property="article:tag" content="博客建站">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"用回valine评论系统,valine评论框样式美化","description":"我感觉我一个处女座的就不应该搞前端，太吹毛求疵追求完美了，哪里有一点点觉得不漂亮就想改 博客的评论系统用过好几家（虽然都没有人评论 比如gitalk，来必力 之前用的来必力，加载慢…","image":"/assets/uploads/2026/05/用回valine评论系统valine评论框样式美化-2d5da13e-01.png","datePublished":"2018-11-01T08:52:05+08:00","dateModified":"2018-11-01T08:52:05+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181101/","keywords":"教程,博客建站"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"用回valine评论系统,valine评论框样式美化","description":"我感觉我一个处女座的就不应该搞前端，太吹毛求疵追求完美了，哪里有一点点觉得不漂亮就想改 博客的评论系统用过好几家（虽然都没有人评论 比如gitalk，来必力 之前用的来必力，加载慢…","image":"https://gitpull.cn/assets/uploads/2026/05/用回valine评论系统valine评论框样式美化-2d5da13e-01.png","datePublished":"2018-11-01T08:52:05+08:00","dateModified":"2018-11-01T08:52:05+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181101/","keywords":"教程,博客建站"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"教程","item":"https://gitpull.cn/tags.html#%E6%95%99%E7%A8%8B"},{"@type":"ListItem","position":3,"name":"用回valine评论系统,valine评论框样式美化","item":"https://gitpull.cn/post/20181101/"}]}</script>
 </head>
 <body>

--- a/post/20181107/index.html
+++ b/post/20181107/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="hexo建站笔记之彩色标签云">
   <meta property="og:description" content="方法比较简单，加个js脚本就好了，至于加载哪里都无所谓了，就放在标签云的页面。 就加在标签的那个页面好了。 1. 打开themes\\\\next\\\\layout\\\\page.swig…">
-  <meta property="og:image" content="/assets/uploads/2026/05/hexo建站笔记之彩色标签云-d6caa003-01.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/hexo建站笔记之彩色标签云-d6caa003-01.png">
   <meta property="og:url" content="https://gitpull.cn/post/20181107/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="hexo建站笔记之彩色标签云">
   <meta name="twitter:description" content="方法比较简单，加个js脚本就好了，至于加载哪里都无所谓了，就放在标签云的页面。 就加在标签的那个页面好了。 1. 打开themes\\\\next\\\\layout\\\\page.swig…">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/hexo建站笔记之彩色标签云-d6caa003-01.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/hexo建站笔记之彩色标签云-d6caa003-01.png">
   <link rel="canonical" href="https://gitpull.cn/post/20181107/">
   <meta property="og:image:width" content="1662">
   <meta property="og:image:height" content="898">
@@ -37,7 +37,7 @@
   <meta property="article:tag" content="教程">
   <meta property="article:tag" content="前端">
   <meta property="article:tag" content="博客建站">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"hexo建站笔记之彩色标签云","description":"方法比较简单，加个js脚本就好了，至于加载哪里都无所谓了，就放在标签云的页面。 就加在标签的那个页面好了。 1. 打开themes\\\\\\\\next\\\\\\\\layout\\\\\\\\page.swig…","image":"/assets/uploads/2026/05/hexo建站笔记之彩色标签云-d6caa003-01.png","datePublished":"2018-11-07T20:08:34+08:00","dateModified":"2018-11-07T20:08:34+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181107/","keywords":"教程,前端,博客建站"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"hexo建站笔记之彩色标签云","description":"方法比较简单，加个js脚本就好了，至于加载哪里都无所谓了，就放在标签云的页面。 就加在标签的那个页面好了。 1. 打开themes\\\\\\\\next\\\\\\\\layout\\\\\\\\page.swig…","image":"https://gitpull.cn/assets/uploads/2026/05/hexo建站笔记之彩色标签云-d6caa003-01.png","datePublished":"2018-11-07T20:08:34+08:00","dateModified":"2018-11-07T20:08:34+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181107/","keywords":"教程,前端,博客建站"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"教程","item":"https://gitpull.cn/tags.html#%E6%95%99%E7%A8%8B"},{"@type":"ListItem","position":3,"name":"hexo建站笔记之彩色标签云","item":"https://gitpull.cn/post/20181107/"}]}</script>
 </head>
 <body>

--- a/post/20181114/index.html
+++ b/post/20181114/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="hexo建站笔记之首页文章轮播图">
   <meta property="og:description" content="¶设计特点 轮播图UI：模仿简书 可以直接在每篇文章的md文件里设置是否要设为轮播图的文章 就是我们每次新写一篇文章，用hexo生成一个md文件，我们只要在头部注明是否要作为轮播图…">
-  <meta property="og:image" content="/assets/uploads/2026/05/hexo建站笔记之首页文章轮播图-6bf81741-01.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/hexo建站笔记之首页文章轮播图-6bf81741-01.png">
   <meta property="og:url" content="https://gitpull.cn/post/20181114/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="hexo建站笔记之首页文章轮播图">
   <meta name="twitter:description" content="¶设计特点 轮播图UI：模仿简书 可以直接在每篇文章的md文件里设置是否要设为轮播图的文章 就是我们每次新写一篇文章，用hexo生成一个md文件，我们只要在头部注明是否要作为轮播图…">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/hexo建站笔记之首页文章轮播图-6bf81741-01.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/hexo建站笔记之首页文章轮播图-6bf81741-01.png">
   <link rel="canonical" href="https://gitpull.cn/post/20181114/">
   <meta property="og:image:width" content="1909">
   <meta property="og:image:height" content="900">
@@ -37,7 +37,7 @@
   <meta property="article:tag" content="教程">
   <meta property="article:tag" content="前端">
   <meta property="article:tag" content="博客建站">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"hexo建站笔记之首页文章轮播图","description":"¶设计特点 轮播图UI：模仿简书 可以直接在每篇文章的md文件里设置是否要设为轮播图的文章 就是我们每次新写一篇文章，用hexo生成一个md文件，我们只要在头部注明是否要作为轮播图…","image":"/assets/uploads/2026/05/hexo建站笔记之首页文章轮播图-6bf81741-01.png","datePublished":"2018-11-14T15:25:40+08:00","dateModified":"2018-11-14T15:25:40+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181114/","keywords":"教程,前端,博客建站"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"hexo建站笔记之首页文章轮播图","description":"¶设计特点 轮播图UI：模仿简书 可以直接在每篇文章的md文件里设置是否要设为轮播图的文章 就是我们每次新写一篇文章，用hexo生成一个md文件，我们只要在头部注明是否要作为轮播图…","image":"https://gitpull.cn/assets/uploads/2026/05/hexo建站笔记之首页文章轮播图-6bf81741-01.png","datePublished":"2018-11-14T15:25:40+08:00","dateModified":"2018-11-14T15:25:40+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181114/","keywords":"教程,前端,博客建站"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"教程","item":"https://gitpull.cn/tags.html#%E6%95%99%E7%A8%8B"},{"@type":"ListItem","position":3,"name":"hexo建站笔记之首页文章轮播图","item":"https://gitpull.cn/post/20181114/"}]}</script>
 </head>
 <body>

--- a/post/20181122/index.html
+++ b/post/20181122/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="使用腾讯云cdn加速博客">
   <meta property="og:description" content="最近把博客搬到腾讯云后，使用腾讯云的COS存储 免费50G的存储空间，放个小博客还是够用的 而且，还可以使用免费的CDN加速 国内访问博客速度比放在GitHub上要快多了 申请腾讯…">
-  <meta property="og:image" content="/assets/uploads/2026/05/使用腾讯云cdn加速博客-1609338289-01.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/使用腾讯云cdn加速博客-1609338289-01.png">
   <meta property="og:url" content="https://gitpull.cn/post/20181122/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="使用腾讯云cdn加速博客">
   <meta name="twitter:description" content="最近把博客搬到腾讯云后，使用腾讯云的COS存储 免费50G的存储空间，放个小博客还是够用的 而且，还可以使用免费的CDN加速 国内访问博客速度比放在GitHub上要快多了 申请腾讯…">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/使用腾讯云cdn加速博客-1609338289-01.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/使用腾讯云cdn加速博客-1609338289-01.png">
   <link rel="canonical" href="https://gitpull.cn/post/20181122/">
   <meta property="og:image:width" content="1002">
   <meta property="og:image:height" content="783">
@@ -36,7 +36,7 @@
   <meta property="article:author" content="兰州小红鸡">
   <meta property="article:tag" content="教程">
   <meta property="article:tag" content="博客建站">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"使用腾讯云cdn加速博客","description":"最近把博客搬到腾讯云后，使用腾讯云的COS存储 免费50G的存储空间，放个小博客还是够用的 而且，还可以使用免费的CDN加速 国内访问博客速度比放在GitHub上要快多了 申请腾讯…","image":"/assets/uploads/2026/05/使用腾讯云cdn加速博客-1609338289-01.png","datePublished":"2018-11-22T19:41:45+08:00","dateModified":"2018-11-22T19:41:45+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181122/","keywords":"教程,博客建站"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"使用腾讯云cdn加速博客","description":"最近把博客搬到腾讯云后，使用腾讯云的COS存储 免费50G的存储空间，放个小博客还是够用的 而且，还可以使用免费的CDN加速 国内访问博客速度比放在GitHub上要快多了 申请腾讯…","image":"https://gitpull.cn/assets/uploads/2026/05/使用腾讯云cdn加速博客-1609338289-01.png","datePublished":"2018-11-22T19:41:45+08:00","dateModified":"2018-11-22T19:41:45+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181122/","keywords":"教程,博客建站"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"教程","item":"https://gitpull.cn/tags.html#%E6%95%99%E7%A8%8B"},{"@type":"ListItem","position":3,"name":"使用腾讯云cdn加速博客","item":"https://gitpull.cn/post/20181122/"}]}</script>
 </head>
 <body>

--- a/post/20181123/index.html
+++ b/post/20181123/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="Dijkstra单源最短路径算法">
   <meta property="og:description" content="算法动态演示地址 今天用c++撸了一遍Dijkstra单源最短路径算法，做个记录,先看下算法的描述 ¶问题描述 给定一个带权有向图 G=(V,E) ，其中每条边的权是一个非负实数。…">
-  <meta property="og:image" content="/assets/uploads/2026/05/Dijkstra单源最短路径算法-15e41f53-01.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/Dijkstra单源最短路径算法-15e41f53-01.png">
   <meta property="og:url" content="https://gitpull.cn/post/20181123/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Dijkstra单源最短路径算法">
   <meta name="twitter:description" content="算法动态演示地址 今天用c++撸了一遍Dijkstra单源最短路径算法，做个记录,先看下算法的描述 ¶问题描述 给定一个带权有向图 G=(V,E) ，其中每条边的权是一个非负实数。…">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/Dijkstra单源最短路径算法-15e41f53-01.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/Dijkstra单源最短路径算法-15e41f53-01.png">
   <link rel="canonical" href="https://gitpull.cn/post/20181123/">
   <meta property="og:image:width" content="1920">
   <meta property="og:image:height" content="974">
@@ -37,7 +37,7 @@
   <meta property="article:tag" content="前端">
   <meta property="article:tag" content="算法">
   <meta property="article:tag" content="C++">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Dijkstra单源最短路径算法","description":"算法动态演示地址 今天用c++撸了一遍Dijkstra单源最短路径算法，做个记录,先看下算法的描述 ¶问题描述 给定一个带权有向图 G=(V,E) ，其中每条边的权是一个非负实数。…","image":"/assets/uploads/2026/05/Dijkstra单源最短路径算法-15e41f53-01.png","datePublished":"2018-11-23T17:32:33+08:00","dateModified":"2018-11-23T17:32:33+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181123/","keywords":"前端,算法,C++"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Dijkstra单源最短路径算法","description":"算法动态演示地址 今天用c++撸了一遍Dijkstra单源最短路径算法，做个记录,先看下算法的描述 ¶问题描述 给定一个带权有向图 G=(V,E) ，其中每条边的权是一个非负实数。…","image":"https://gitpull.cn/assets/uploads/2026/05/Dijkstra单源最短路径算法-15e41f53-01.png","datePublished":"2018-11-23T17:32:33+08:00","dateModified":"2018-11-23T17:32:33+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181123/","keywords":"前端,算法,C++"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"前端","item":"https://gitpull.cn/tags.html#%E5%89%8D%E7%AB%AF"},{"@type":"ListItem","position":3,"name":"Dijkstra单源最短路径算法","item":"https://gitpull.cn/post/20181123/"}]}</script>
 </head>
 <body>

--- a/post/20181206/index.html
+++ b/post/20181206/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="12月6日杂谈">
   <meta property="og:description" content="今天是12月6日，周四，没课 小雪，温度零下好多度 早上去了会儿图书馆，没看下书，下午在宿舍荒废了一下午，满满的罪恶感。 18年就剩下20多天了，这学期开学前立下的目标，慢慢丢失的…">
-  <meta property="og:image" content="/assets/uploads/2026/05/12月6日杂谈-5027c817-01.jpg">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/12月6日杂谈-5027c817-01.jpg">
   <meta property="og:url" content="https://gitpull.cn/post/20181206/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="12月6日杂谈">
   <meta name="twitter:description" content="今天是12月6日，周四，没课 小雪，温度零下好多度 早上去了会儿图书馆，没看下书，下午在宿舍荒废了一下午，满满的罪恶感。 18年就剩下20多天了，这学期开学前立下的目标，慢慢丢失的…">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/12月6日杂谈-5027c817-01.jpg">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/12月6日杂谈-5027c817-01.jpg">
   <link rel="canonical" href="https://gitpull.cn/post/20181206/">
   <meta property="og:image:width" content="700">
   <meta property="og:image:height" content="394">
@@ -35,7 +35,7 @@
   <meta property="article:modified_time" content="2018-12-06T17:13:48+08:00">
   <meta property="article:author" content="兰州小红鸡">
   <meta property="article:tag" content="随想">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"12月6日杂谈","description":"今天是12月6日，周四，没课 小雪，温度零下好多度 早上去了会儿图书馆，没看下书，下午在宿舍荒废了一下午，满满的罪恶感。 18年就剩下20多天了，这学期开学前立下的目标，慢慢丢失的…","image":"/assets/uploads/2026/05/12月6日杂谈-5027c817-01.jpg","datePublished":"2018-12-06T17:13:48+08:00","dateModified":"2018-12-06T17:13:48+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181206/","keywords":"随想"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"12月6日杂谈","description":"今天是12月6日，周四，没课 小雪，温度零下好多度 早上去了会儿图书馆，没看下书，下午在宿舍荒废了一下午，满满的罪恶感。 18年就剩下20多天了，这学期开学前立下的目标，慢慢丢失的…","image":"https://gitpull.cn/assets/uploads/2026/05/12月6日杂谈-5027c817-01.jpg","datePublished":"2018-12-06T17:13:48+08:00","dateModified":"2018-12-06T17:13:48+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181206/","keywords":"随想"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"随想","item":"https://gitpull.cn/tags.html#%E9%9A%8F%E6%83%B3"},{"@type":"ListItem","position":3,"name":"12月6日杂谈","item":"https://gitpull.cn/post/20181206/"}]}</script>
 </head>
 <body>

--- a/post/20181214/index.html
+++ b/post/20181214/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="Windows下的终端折腾——弃坑msys2，开始用wsl">
   <meta property="og:description" content="之前用了半年Linux，后来因为平常一些软件需要，只能在Windows下玩，就换回Windows了。 但还是万分想念Linux，然而Windows下的终端一直用的不爽，就一直在尝试…">
-  <meta property="og:image" content="/assets/uploads/2026/05/Windows下的终端折腾——弃坑msys2开始用wsl-d6b124c4-03.gif">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/Windows下的终端折腾——弃坑msys2开始用wsl-d6b124c4-03.gif">
   <meta property="og:url" content="https://gitpull.cn/post/20181214/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Windows下的终端折腾——弃坑msys2，开始用wsl">
   <meta name="twitter:description" content="之前用了半年Linux，后来因为平常一些软件需要，只能在Windows下玩，就换回Windows了。 但还是万分想念Linux，然而Windows下的终端一直用的不爽，就一直在尝试…">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/Windows下的终端折腾——弃坑msys2开始用wsl-d6b124c4-03.gif">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/Windows下的终端折腾——弃坑msys2开始用wsl-d6b124c4-03.gif">
   <link rel="canonical" href="https://gitpull.cn/post/20181214/">
   <meta property="og:image:width" content="1424">
   <meta property="og:image:height" content="862">
@@ -35,7 +35,7 @@
   <meta property="article:modified_time" content="2018-12-14T10:50:18+08:00">
   <meta property="article:author" content="兰州小红鸡">
   <meta property="article:tag" content="教程">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Windows下的终端折腾——弃坑msys2，开始用wsl","description":"之前用了半年Linux，后来因为平常一些软件需要，只能在Windows下玩，就换回Windows了。 但还是万分想念Linux，然而Windows下的终端一直用的不爽，就一直在尝试…","image":"/assets/uploads/2026/05/Windows下的终端折腾——弃坑msys2开始用wsl-d6b124c4-03.gif","datePublished":"2018-12-14T10:50:18+08:00","dateModified":"2018-12-14T10:50:18+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181214/","keywords":"教程"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Windows下的终端折腾——弃坑msys2，开始用wsl","description":"之前用了半年Linux，后来因为平常一些软件需要，只能在Windows下玩，就换回Windows了。 但还是万分想念Linux，然而Windows下的终端一直用的不爽，就一直在尝试…","image":"https://gitpull.cn/assets/uploads/2026/05/Windows下的终端折腾——弃坑msys2开始用wsl-d6b124c4-03.gif","datePublished":"2018-12-14T10:50:18+08:00","dateModified":"2018-12-14T10:50:18+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20181214/","keywords":"教程"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"教程","item":"https://gitpull.cn/tags.html#%E6%95%99%E7%A8%8B"},{"@type":"ListItem","position":3,"name":"Windows下的终端折腾——弃坑msys2，开始用wsl","item":"https://gitpull.cn/post/20181214/"}]}</script>
 </head>
 <body>

--- a/post/20220310/index.html
+++ b/post/20220310/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="nebula代码走读——从Validator到Executor">
   <meta property="og:description" content="整体架构 Nebula Graph Query Engine 主要分为四个模块，分别是 Parser、Validator、Optimizer 和 Executor。 Parser …">
-  <meta property="og:image" content="/assets/uploads/2026/05/nebula代码走读——从Validator到Executor-15988828-01.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/nebula代码走读——从Validator到Executor-15988828-01.png">
   <meta property="og:url" content="https://gitpull.cn/post/20220310/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="nebula代码走读——从Validator到Executor">
   <meta name="twitter:description" content="整体架构 Nebula Graph Query Engine 主要分为四个模块，分别是 Parser、Validator、Optimizer 和 Executor。 Parser …">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/nebula代码走读——从Validator到Executor-15988828-01.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/nebula代码走读——从Validator到Executor-15988828-01.png">
   <link rel="canonical" href="https://gitpull.cn/post/20220310/">
   <meta property="og:image:width" content="897">
   <meta property="og:image:height" content="150">
@@ -35,7 +35,7 @@
   <meta property="article:modified_time" content="2022-03-10T11:41:00+08:00">
   <meta property="article:author" content="兰州小红鸡">
   <meta property="article:tag" content="图数据库">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"nebula代码走读——从Validator到Executor","description":"整体架构 Nebula Graph Query Engine 主要分为四个模块，分别是 Parser、Validator、Optimizer 和 Executor。 Parser …","image":"/assets/uploads/2026/05/nebula代码走读——从Validator到Executor-15988828-01.png","datePublished":"2022-03-10T11:41:00+08:00","dateModified":"2022-03-10T11:41:00+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20220310/","keywords":"图数据库"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"nebula代码走读——从Validator到Executor","description":"整体架构 Nebula Graph Query Engine 主要分为四个模块，分别是 Parser、Validator、Optimizer 和 Executor。 Parser …","image":"https://gitpull.cn/assets/uploads/2026/05/nebula代码走读——从Validator到Executor-15988828-01.png","datePublished":"2022-03-10T11:41:00+08:00","dateModified":"2022-03-10T11:41:00+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20220310/","keywords":"图数据库"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"图数据库","item":"https://gitpull.cn/tags.html#%E5%9B%BE%E6%95%B0%E6%8D%AE%E5%BA%93"},{"@type":"ListItem","position":3,"name":"nebula代码走读——从Validator到Executor","item":"https://gitpull.cn/post/20220310/"}]}</script>
 </head>
 <body>

--- a/post/20220311/index.html
+++ b/post/20220311/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="nebula graph 图计算数据库">
   <meta property="og:description" content="更新历史 在学习过程中，本文持续更新 2021 12 13：更新nebula官方介绍 2021 12 14：更新编译与部署方式，总结importer导入方式 2021 12 15：…">
-  <meta property="og:image" content="/assets/uploads/2026/05/置顶-nebula-graph-图计算数据库-15993772-02.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/置顶-nebula-graph-图计算数据库-15993772-02.png">
   <meta property="og:url" content="https://gitpull.cn/post/20220311/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,14 +27,14 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="nebula graph 图计算数据库">
   <meta name="twitter:description" content="更新历史 在学习过程中，本文持续更新 2021 12 13：更新nebula官方介绍 2021 12 14：更新编译与部署方式，总结importer导入方式 2021 12 15：…">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/置顶-nebula-graph-图计算数据库-15993772-02.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/置顶-nebula-graph-图计算数据库-15993772-02.png">
   <link rel="canonical" href="https://gitpull.cn/post/20220311/">
   <meta property="og:image:width" content="900">
   <meta property="og:image:height" content="521">
   <meta property="article:published_time" content="2022-03-11T15:03:00+08:00">
   <meta property="article:modified_time" content="2022-03-11T15:03:00+08:00">
   <meta property="article:author" content="兰州小红鸡">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"nebula graph 图计算数据库","description":"更新历史 在学习过程中，本文持续更新 2021 12 13：更新nebula官方介绍 2021 12 14：更新编译与部署方式，总结importer导入方式 2021 12 15：…","image":"/assets/uploads/2026/05/置顶-nebula-graph-图计算数据库-15993772-02.png","datePublished":"2022-03-11T15:03:00+08:00","dateModified":"2022-03-11T15:03:00+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20220311/"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"nebula graph 图计算数据库","description":"更新历史 在学习过程中，本文持续更新 2021 12 13：更新nebula官方介绍 2021 12 14：更新编译与部署方式，总结importer导入方式 2021 12 15：…","image":"https://gitpull.cn/assets/uploads/2026/05/置顶-nebula-graph-图计算数据库-15993772-02.png","datePublished":"2022-03-11T15:03:00+08:00","dateModified":"2022-03-11T15:03:00+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20220311/"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"nebula graph 图计算数据库","item":"https://gitpull.cn/post/20220311/"}]}</script>
 </head>
 <body>

--- a/post/20220312/index.html
+++ b/post/20220312/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="推荐系统——推荐引擎的架构">
   <meta property="og:description" content="什么是推荐系统 谈推荐系统之前我们先聊一下搜索系统，推荐系统和搜索系统都是为了解决互联网信息过载的问题，互联网信息的数量远超过人类可以逐一浏览的程度，而搜索引擎便是解决这一问题的代…">
-  <meta property="og:image" content="/assets/uploads/2026/05/推荐系统——推荐引擎的架构-15996742-02.jpg">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/推荐系统——推荐引擎的架构-15996742-02.jpg">
   <meta property="og:url" content="https://gitpull.cn/post/20220312/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,14 +27,14 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="推荐系统——推荐引擎的架构">
   <meta name="twitter:description" content="什么是推荐系统 谈推荐系统之前我们先聊一下搜索系统，推荐系统和搜索系统都是为了解决互联网信息过载的问题，互联网信息的数量远超过人类可以逐一浏览的程度，而搜索引擎便是解决这一问题的代…">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/推荐系统——推荐引擎的架构-15996742-02.jpg">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/推荐系统——推荐引擎的架构-15996742-02.jpg">
   <link rel="canonical" href="https://gitpull.cn/post/20220312/">
   <meta property="og:image:width" content="1013">
   <meta property="og:image:height" content="953">
   <meta property="article:published_time" content="2022-03-12T11:31:00+08:00">
   <meta property="article:modified_time" content="2022-03-12T11:31:00+08:00">
   <meta property="article:author" content="兰州小红鸡">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"推荐系统——推荐引擎的架构","description":"什么是推荐系统 谈推荐系统之前我们先聊一下搜索系统，推荐系统和搜索系统都是为了解决互联网信息过载的问题，互联网信息的数量远超过人类可以逐一浏览的程度，而搜索引擎便是解决这一问题的代…","image":"/assets/uploads/2026/05/推荐系统——推荐引擎的架构-15996742-02.jpg","datePublished":"2022-03-12T11:31:00+08:00","dateModified":"2022-03-12T11:31:00+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20220312/"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"推荐系统——推荐引擎的架构","description":"什么是推荐系统 谈推荐系统之前我们先聊一下搜索系统，推荐系统和搜索系统都是为了解决互联网信息过载的问题，互联网信息的数量远超过人类可以逐一浏览的程度，而搜索引擎便是解决这一问题的代…","image":"https://gitpull.cn/assets/uploads/2026/05/推荐系统——推荐引擎的架构-15996742-02.jpg","datePublished":"2022-03-12T11:31:00+08:00","dateModified":"2022-03-12T11:31:00+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20220312/"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"推荐系统——推荐引擎的架构","item":"https://gitpull.cn/post/20220312/"}]}</script>
 </head>
 <body>

--- a/post/20220313/index.html
+++ b/post/20220313/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="多维数组的索引方案与内存设计">
   <meta property="og:description" content="多维数组的内存结构 类似ndarray之类的多维数组，实际上是一个连续的内存地址+一种索引方案。我们可以将一个多维数组对象分为两部分，一部分是实际存储数组数据的连续内存段，另一部分…">
-  <meta property="og:image" content="/assets/uploads/2026/05/多维数组的索引方案与内存设计-16000038-01.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/多维数组的索引方案与内存设计-16000038-01.png">
   <meta property="og:url" content="https://gitpull.cn/post/20220313/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,14 +27,14 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="多维数组的索引方案与内存设计">
   <meta name="twitter:description" content="多维数组的内存结构 类似ndarray之类的多维数组，实际上是一个连续的内存地址+一种索引方案。我们可以将一个多维数组对象分为两部分，一部分是实际存储数组数据的连续内存段，另一部分…">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/多维数组的索引方案与内存设计-16000038-01.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/多维数组的索引方案与内存设计-16000038-01.png">
   <link rel="canonical" href="https://gitpull.cn/post/20220313/">
   <meta property="og:image:width" content="1076">
   <meta property="og:image:height" content="210">
   <meta property="article:published_time" content="2022-03-13T12:08:00+08:00">
   <meta property="article:modified_time" content="2022-03-13T12:08:00+08:00">
   <meta property="article:author" content="兰州小红鸡">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"多维数组的索引方案与内存设计","description":"多维数组的内存结构 类似ndarray之类的多维数组，实际上是一个连续的内存地址+一种索引方案。我们可以将一个多维数组对象分为两部分，一部分是实际存储数组数据的连续内存段，另一部分…","image":"/assets/uploads/2026/05/多维数组的索引方案与内存设计-16000038-01.png","datePublished":"2022-03-13T12:08:00+08:00","dateModified":"2022-03-13T12:08:00+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20220313/"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"多维数组的索引方案与内存设计","description":"多维数组的内存结构 类似ndarray之类的多维数组，实际上是一个连续的内存地址+一种索引方案。我们可以将一个多维数组对象分为两部分，一部分是实际存储数组数据的连续内存段，另一部分…","image":"https://gitpull.cn/assets/uploads/2026/05/多维数组的索引方案与内存设计-16000038-01.png","datePublished":"2022-03-13T12:08:00+08:00","dateModified":"2022-03-13T12:08:00+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20220313/"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"多维数组的索引方案与内存设计","item":"https://gitpull.cn/post/20220313/"}]}</script>
 </head>
 <body>

--- a/post/20260311/index.html
+++ b/post/20260311/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="3FS 的零拷贝之路：USRBIO 是怎么把存储吞吐推到 6.6 TiB/s 的">
   <meta property="og:description" content="DeepSeek 开源的 3FS 在 180 节点集群上实测聚合读取吞吐约 6.6 TiB/s。本文从 FUSE 的性能瓶颈讲起，拆解 3FS 如何通过共享内存、io_uring 风格的环形队列、以及 RDMA 直接传输三层叠加，把数据通路上的每一次拷贝都抠掉。">
-  <meta property="og:image" content="/assets/uploads/2026/05/3fs-usrbio-cover.webp">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/3fs-usrbio-cover.webp">
   <meta property="og:url" content="https://gitpull.cn/post/20260311/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="3FS 的零拷贝之路：USRBIO 是怎么把存储吞吐推到 6.6 TiB/s 的">
   <meta name="twitter:description" content="DeepSeek 开源的 3FS 在 180 节点集群上实测聚合读取吞吐约 6.6 TiB/s。本文从 FUSE 的性能瓶颈讲起，拆解 3FS 如何通过共享内存、io_uring 风格的环形队列、以及 RDMA 直接传输三层叠加，把数据通路上的每一次拷贝都抠掉。">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/3fs-usrbio-cover.webp">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/3fs-usrbio-cover.webp">
   <link rel="canonical" href="https://gitpull.cn/post/20260311/">
   <meta property="og:image:width" content="1600">
   <meta property="og:image:height" content="560">
@@ -37,7 +37,7 @@
   <meta property="article:tag" content="分布式存储">
   <meta property="article:tag" content="AI 基础设施">
   <meta property="article:tag" content="C++">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"3FS 的零拷贝之路：USRBIO 是怎么把存储吞吐推到 6.6 TiB/s 的","description":"DeepSeek 开源的 3FS 在 180 节点集群上实测聚合读取吞吐约 6.6 TiB/s。本文从 FUSE 的性能瓶颈讲起，拆解 3FS 如何通过共享内存、io_uring 风格的环形队列、以及 RDMA 直接传输三层叠加，把数据通路上的每一次拷贝都抠掉。","image":"/assets/uploads/2026/05/3fs-usrbio-cover.webp","datePublished":"2026-03-11","dateModified":"2026-05-12","author":{"@type":"Person","name":"Jimmy"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20260311/","keywords":"分布式存储,AI 基础设施,C++"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"3FS 的零拷贝之路：USRBIO 是怎么把存储吞吐推到 6.6 TiB/s 的","description":"DeepSeek 开源的 3FS 在 180 节点集群上实测聚合读取吞吐约 6.6 TiB/s。本文从 FUSE 的性能瓶颈讲起，拆解 3FS 如何通过共享内存、io_uring 风格的环形队列、以及 RDMA 直接传输三层叠加，把数据通路上的每一次拷贝都抠掉。","image":"https://gitpull.cn/assets/uploads/2026/05/3fs-usrbio-cover.webp","datePublished":"2026-03-11","dateModified":"2026-05-12","author":{"@type":"Person","name":"Jimmy"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20260311/","keywords":"分布式存储,AI 基础设施,C++"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"分布式存储","item":"https://gitpull.cn/tags.html#%E5%88%86%E5%B8%83%E5%BC%8F%E5%AD%98%E5%82%A8"},{"@type":"ListItem","position":3,"name":"3FS 的零拷贝之路：USRBIO 是怎么把存储吞吐推到 6.6 TiB/s 的","item":"https://gitpull.cn/post/20260311/"}]}</script>
 </head>
 <body>

--- a/post/20260415/index.html
+++ b/post/20260415/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="Smallpond 源码走读：DuckDB × 3FS × Ray 是如何拼成一台分布式数据处理机的">
   <meta property="og:description" content="Smallpond 是 DeepSeek 开源的轻量级分布式数据处理框架，专为 10 TB 到 PB 量级的 AI / 数据场景设计。它把 DuckDB 的列式向量化执行、3FS 的高带宽存储、Ray 的任务调度三块拼到一起，做成了\&quot;一台机器\&quot;。本文从架构分层、端到端工作流、Parquet 基础到核心源码走读，把这台\&quot;机器\&quot;的工作原理说清楚。">
-  <meta property="og:image" content="/assets/uploads/2026/05/smallpond-cover.webp">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/smallpond-cover.webp">
   <meta property="og:url" content="https://gitpull.cn/post/20260415/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Smallpond 源码走读：DuckDB × 3FS × Ray 是如何拼成一台分布式数据处理机的">
   <meta name="twitter:description" content="Smallpond 是 DeepSeek 开源的轻量级分布式数据处理框架，专为 10 TB 到 PB 量级的 AI / 数据场景设计。它把 DuckDB 的列式向量化执行、3FS 的高带宽存储、Ray 的任务调度三块拼到一起，做成了\&quot;一台机器\&quot;。本文从架构分层、端到端工作流、Parquet 基础到核心源码走读，把这台\&quot;机器\&quot;的工作原理说清楚。">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/smallpond-cover.webp">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/smallpond-cover.webp">
   <link rel="canonical" href="https://gitpull.cn/post/20260415/">
   <meta property="og:image:width" content="1600">
   <meta property="og:image:height" content="1200">
@@ -37,7 +37,7 @@
   <meta property="article:tag" content="分布式存储">
   <meta property="article:tag" content="AI 基础设施">
   <meta property="article:tag" content="python">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Smallpond 源码走读：DuckDB × 3FS × Ray 是如何拼成一台分布式数据处理机的","description":"Smallpond 是 DeepSeek 开源的轻量级分布式数据处理框架，专为 10 TB 到 PB 量级的 AI / 数据场景设计。它把 DuckDB 的列式向量化执行、3FS 的高带宽存储、Ray 的任务调度三块拼到一起，做成了\\\"一台机器\\\"。本文从架构分层、端到端工作流、Parquet 基础到核心源码走读，把这台\\\"机器\\\"的工作原理说清楚。","image":"/assets/uploads/2026/05/smallpond-cover.webp","datePublished":"2026-04-15","dateModified":"2026-05-12","author":{"@type":"Person","name":"Jimmy"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20260415/","keywords":"分布式存储,AI 基础设施,python"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Smallpond 源码走读：DuckDB × 3FS × Ray 是如何拼成一台分布式数据处理机的","description":"Smallpond 是 DeepSeek 开源的轻量级分布式数据处理框架，专为 10 TB 到 PB 量级的 AI / 数据场景设计。它把 DuckDB 的列式向量化执行、3FS 的高带宽存储、Ray 的任务调度三块拼到一起，做成了\\\"一台机器\\\"。本文从架构分层、端到端工作流、Parquet 基础到核心源码走读，把这台\\\"机器\\\"的工作原理说清楚。","image":"https://gitpull.cn/assets/uploads/2026/05/smallpond-cover.webp","datePublished":"2026-04-15","dateModified":"2026-05-12","author":{"@type":"Person","name":"Jimmy"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20260415/","keywords":"分布式存储,AI 基础设施,python"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"分布式存储","item":"https://gitpull.cn/tags.html#%E5%88%86%E5%B8%83%E5%BC%8F%E5%AD%98%E5%82%A8"},{"@type":"ListItem","position":3,"name":"Smallpond 源码走读：DuckDB × 3FS × Ray 是如何拼成一台分布式数据处理机的","item":"https://gitpull.cn/post/20260415/"}]}</script>
 </head>
 <body>

--- a/post/20260514/index.html
+++ b/post/20260514/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="CPTI：手机上就能玩的恋爱人格小测验">
   <meta property="og:description" content="CPTI 是一个偏手机体验的恋爱向趣味测验：刷题像刷短内容，最后给你「你像谁」和「谁更适合接住你」两套结果，再配一整套恋爱角色卡。本文只聊怎么玩、能玩出什么，不聊实现细节。">
-  <meta property="og:image" content="/assets/uploads/2026/05/cptijietu1.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/cptijietu1.png">
   <meta property="og:url" content="https://gitpull.cn/post/20260514/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="CPTI：手机上就能玩的恋爱人格小测验">
   <meta name="twitter:description" content="CPTI 是一个偏手机体验的恋爱向趣味测验：刷题像刷短内容，最后给你「你像谁」和「谁更适合接住你」两套结果，再配一整套恋爱角色卡。本文只聊怎么玩、能玩出什么，不聊实现细节。">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/cptijietu1.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/cptijietu1.png">
   <link rel="canonical" href="https://gitpull.cn/post/20260514/">
   <meta property="og:image:width" content="637">
   <meta property="og:image:height" content="1262">
@@ -36,7 +36,7 @@
   <meta property="article:author" content="Jimmy">
   <meta property="article:tag" content="杂七杂八">
   <meta property="article:tag" content="前端">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"CPTI：手机上就能玩的恋爱人格小测验","description":"CPTI 是一个偏手机体验的恋爱向趣味测验：刷题像刷短内容，最后给你「你像谁」和「谁更适合接住你」两套结果，再配一整套恋爱角色卡。本文只聊怎么玩、能玩出什么，不聊实现细节。","image":"/assets/uploads/2026/05/cptijietu1.png","datePublished":"2026-05-14","dateModified":"2026-05-15T03:55:33.008Z","author":{"@type":"Person","name":"Jimmy"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20260514/","keywords":"杂七杂八,前端"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"CPTI：手机上就能玩的恋爱人格小测验","description":"CPTI 是一个偏手机体验的恋爱向趣味测验：刷题像刷短内容，最后给你「你像谁」和「谁更适合接住你」两套结果，再配一整套恋爱角色卡。本文只聊怎么玩、能玩出什么，不聊实现细节。","image":"https://gitpull.cn/assets/uploads/2026/05/cptijietu1.png","datePublished":"2026-05-14","dateModified":"2026-05-15T03:55:33.008Z","author":{"@type":"Person","name":"Jimmy"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20260514/","keywords":"杂七杂八,前端"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"杂七杂八","item":"https://gitpull.cn/tags.html#%E6%9D%82%E4%B8%83%E6%9D%82%E5%85%AB"},{"@type":"ListItem","position":3,"name":"CPTI：手机上就能玩的恋爱人格小测验","item":"https://gitpull.cn/post/20260514/"}]}</script>
 </head>
 <body>

--- a/post/20260529/index.html
+++ b/post/20260529/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="大模型推理的 PD 分离：原理、动机与 Mooncake 的实现">
   <meta property="og:description" content="当我们谈论 LLM 推理优化时，绕不开一个关键词—— PD 分离 （Prefill Decode Disaggregation）。这篇文章从第一性原理出发，讲清…">
-  <meta property="og:image" content="/assets/uploads/2026/05/1780025971901-bu285b-image.webp">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/1780025971901-bu285b-image.webp">
   <meta property="og:url" content="https://gitpull.cn/post/20260529/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="大模型推理的 PD 分离：原理、动机与 Mooncake 的实现">
   <meta name="twitter:description" content="当我们谈论 LLM 推理优化时，绕不开一个关键词—— PD 分离 （Prefill Decode Disaggregation）。这篇文章从第一性原理出发，讲清…">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/1780025971901-bu285b-image.webp">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/1780025971901-bu285b-image.webp">
   <link rel="canonical" href="https://gitpull.cn/post/20260529/">
   <meta property="og:image:width" content="581">
   <meta property="og:image:height" content="325">
@@ -36,7 +36,7 @@
   <meta property="article:author" content="兰州小红鸡">
   <meta property="article:tag" content="算法">
   <meta property="article:tag" content="分布式存储">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"大模型推理的 PD 分离：原理、动机与 Mooncake 的实现","description":"当我们谈论 LLM 推理优化时，绕不开一个关键词—— PD 分离 （Prefill Decode Disaggregation）。这篇文章从第一性原理出发，讲清…","image":"/assets/uploads/2026/05/1780025971901-bu285b-image.webp","datePublished":"2026-05-29T03:40:23.322Z","dateModified":"2026-05-29T03:40:23.322Z","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20260529/","keywords":"算法,分布式存储"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"大模型推理的 PD 分离：原理、动机与 Mooncake 的实现","description":"当我们谈论 LLM 推理优化时，绕不开一个关键词—— PD 分离 （Prefill Decode Disaggregation）。这篇文章从第一性原理出发，讲清…","image":"https://gitpull.cn/assets/uploads/2026/05/1780025971901-bu285b-image.webp","datePublished":"2026-05-29T03:40:23.322Z","dateModified":"2026-05-29T03:40:23.322Z","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20260529/","keywords":"算法,分布式存储"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"算法","item":"https://gitpull.cn/tags.html#%E7%AE%97%E6%B3%95"},{"@type":"ListItem","position":3,"name":"大模型推理的 PD 分离：原理、动机与 Mooncake 的实现","item":"https://gitpull.cn/post/20260529/"}]}</script>
 </head>
 <body>

--- a/post/20260601/index.html
+++ b/post/20260601/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="PeerCache：一个去中心化的 RDMA 零拷贝 KV 缓存后端">
   <meta property="og:description" content="PeerCache 是我写的一个面向 SGLang HiCache 的 L3 KV 缓存后端：它做的是跨请求、跨节点的 KV 前缀复用，提供和 Mooncake Store 类似的能力，却砍掉了中心化的 master 与 metadata 服务。单卡能吃到裸 ib_read_bw 的 94%，整机 8 卡聚合 413 GB/s。这篇文章讲清楚它的定位、为什么这样设计、双 MR 模型怎么工作，以及实测性能基线。">
-  <meta property="og:image" content="/assets/uploads/2026/06/peercache_scaling_ladder.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/06/peercache_scaling_ladder.png">
   <meta property="og:url" content="https://gitpull.cn/post/20260601/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="PeerCache：一个去中心化的 RDMA 零拷贝 KV 缓存后端">
   <meta name="twitter:description" content="PeerCache 是我写的一个面向 SGLang HiCache 的 L3 KV 缓存后端：它做的是跨请求、跨节点的 KV 前缀复用，提供和 Mooncake Store 类似的能力，却砍掉了中心化的 master 与 metadata 服务。单卡能吃到裸 ib_read_bw 的 94%，整机 8 卡聚合 413 GB/s。这篇文章讲清楚它的定位、为什么这样设计、双 MR 模型怎么工作，以及实测性能基线。">
-  <meta name="twitter:image" content="/assets/uploads/2026/06/peercache_scaling_ladder.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/06/peercache_scaling_ladder.png">
   <link rel="canonical" href="https://gitpull.cn/post/20260601/">
   <meta property="og:image:width" content="1120">
   <meta property="og:image:height" content="560">
@@ -37,7 +37,7 @@
   <meta property="article:tag" content="分布式存储">
   <meta property="article:tag" content="AI 基础设施">
   <meta property="article:tag" content="项目介绍">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"PeerCache：一个去中心化的 RDMA 零拷贝 KV 缓存后端","description":"PeerCache 是我写的一个面向 SGLang HiCache 的 L3 KV 缓存后端：它做的是跨请求、跨节点的 KV 前缀复用，提供和 Mooncake Store 类似的能力，却砍掉了中心化的 master 与 metadata 服务。单卡能吃到裸 ib_read_bw 的 94%，整机 8 卡聚合 413 GB/s。这篇文章讲清楚它的定位、为什么这样设计、双 MR 模型怎么工作，以及实测性能基线。","image":"/assets/uploads/2026/06/peercache_scaling_ladder.png","datePublished":"2026-06-01T10:00:00+08:00","dateModified":"2026-06-02T00:30:00+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20260601/","keywords":"分布式存储,AI 基础设施,项目介绍"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"PeerCache：一个去中心化的 RDMA 零拷贝 KV 缓存后端","description":"PeerCache 是我写的一个面向 SGLang HiCache 的 L3 KV 缓存后端：它做的是跨请求、跨节点的 KV 前缀复用，提供和 Mooncake Store 类似的能力，却砍掉了中心化的 master 与 metadata 服务。单卡能吃到裸 ib_read_bw 的 94%，整机 8 卡聚合 413 GB/s。这篇文章讲清楚它的定位、为什么这样设计、双 MR 模型怎么工作，以及实测性能基线。","image":"https://gitpull.cn/assets/uploads/2026/06/peercache_scaling_ladder.png","datePublished":"2026-06-01T10:00:00+08:00","dateModified":"2026-06-02T00:30:00+08:00","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20260601/","keywords":"分布式存储,AI 基础设施,项目介绍"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"分布式存储","item":"https://gitpull.cn/tags.html#%E5%88%86%E5%B8%83%E5%BC%8F%E5%AD%98%E5%82%A8"},{"@type":"ListItem","position":3,"name":"PeerCache：一个去中心化的 RDMA 零拷贝 KV 缓存后端","item":"https://gitpull.cn/post/20260601/"}]}</script>
 </head>
 <body>

--- a/post/20260615/index.html
+++ b/post/20260615/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="用 AI 做好软件项目：上下文工程实践指南">
   <meta property="og:description" content="在复杂软件项目中引入 AI，常见困境不是模型不够强，而是 每次会话都在重复建立上下文 ——Agent 全量读取大文件、反复追问架构、上一轮的结论无法延续、任务边…">
-  <meta property="og:image" content="/assets/uploads/2026/06/1781499659393-4hzbpp-image.webp">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/06/1781499659393-4hzbpp-image.webp">
   <meta property="og:url" content="https://gitpull.cn/post/20260615/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="用 AI 做好软件项目：上下文工程实践指南">
   <meta name="twitter:description" content="在复杂软件项目中引入 AI，常见困境不是模型不够强，而是 每次会话都在重复建立上下文 ——Agent 全量读取大文件、反复追问架构、上一轮的结论无法延续、任务边…">
-  <meta name="twitter:image" content="/assets/uploads/2026/06/1781499659393-4hzbpp-image.webp">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/06/1781499659393-4hzbpp-image.webp">
   <link rel="canonical" href="https://gitpull.cn/post/20260615/">
   <meta property="og:image:width" content="1058">
   <meta property="og:image:height" content="821">
@@ -35,7 +35,7 @@
   <meta property="article:modified_time" content="2026-06-15T05:03:50.209Z">
   <meta property="article:author" content="兰州小红鸡">
   <meta property="article:tag" content="AI 基础设施">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"用 AI 做好软件项目：上下文工程实践指南","description":"在复杂软件项目中引入 AI，常见困境不是模型不够强，而是 每次会话都在重复建立上下文 ——Agent 全量读取大文件、反复追问架构、上一轮的结论无法延续、任务边…","image":"/assets/uploads/2026/06/1781499659393-4hzbpp-image.webp","datePublished":"2026-06-15T04:56:47.024Z","dateModified":"2026-06-15T05:03:50.209Z","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20260615/","keywords":"AI 基础设施"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"用 AI 做好软件项目：上下文工程实践指南","description":"在复杂软件项目中引入 AI，常见困境不是模型不够强，而是 每次会话都在重复建立上下文 ——Agent 全量读取大文件、反复追问架构、上一轮的结论无法延续、任务边…","image":"https://gitpull.cn/assets/uploads/2026/06/1781499659393-4hzbpp-image.webp","datePublished":"2026-06-15T04:56:47.024Z","dateModified":"2026-06-15T05:03:50.209Z","author":{"@type":"Person","name":"兰州小红鸡"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20260615/","keywords":"AI 基础设施"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"AI 基础设施","item":"https://gitpull.cn/tags.html#AI%20%E5%9F%BA%E7%A1%80%E8%AE%BE%E6%96%BD"},{"@type":"ListItem","position":3,"name":"用 AI 做好软件项目：上下文工程实践指南","item":"https://gitpull.cn/post/20260615/"}]}</script>
 </head>
 <body>

--- a/post/20260618/index.html
+++ b/post/20260618/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="海门回声 | 黑鬼">
   <meta property="og:description" content="黑鬼已经死了好多年了，大概在我上初中还是高中的时候。听大人们说，是在某一年的春节里，二月的天气还很冷，他像往常一样被铁链子拴在家院子前面的小屋子里，有好几天家人忘了给他送饭，便饿死了。也有人说是冻死的。我后来真的见过他——脸发青，像苔藓，不像电视剧里画着黑眼圈的饿汉。">
-  <meta property="og:image" content="/assets/uploads/2026/06/heigui-cover.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/06/heigui-cover.png">
   <meta property="og:url" content="https://gitpull.cn/post/20260618/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="海门回声 | 黑鬼">
   <meta name="twitter:description" content="黑鬼已经死了好多年了，大概在我上初中还是高中的时候。听大人们说，是在某一年的春节里，二月的天气还很冷，他像往常一样被铁链子拴在家院子前面的小屋子里，有好几天家人忘了给他送饭，便饿死了。也有人说是冻死的。我后来真的见过他——脸发青，像苔藓，不像电视剧里画着黑眼圈的饿汉。">
-  <meta name="twitter:image" content="/assets/uploads/2026/06/heigui-cover.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/06/heigui-cover.png">
   <link rel="canonical" href="https://gitpull.cn/post/20260618/">
   <meta property="og:image:width" content="1536">
   <meta property="og:image:height" content="1024">
@@ -36,7 +36,7 @@
   <meta property="article:author" content="邻家酒肆">
   <meta property="article:tag" content="海门回声">
   <meta property="article:tag" content="随想">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"海门回声 | 黑鬼","description":"黑鬼已经死了好多年了，大概在我上初中还是高中的时候。听大人们说，是在某一年的春节里，二月的天气还很冷，他像往常一样被铁链子拴在家院子前面的小屋子里，有好几天家人忘了给他送饭，便饿死了。也有人说是冻死的。我后来真的见过他——脸发青，像苔藓，不像电视剧里画着黑眼圈的饿汉。","image":"/assets/uploads/2026/06/heigui-cover.png","datePublished":"2026-06-18T20:00:00+08:00","dateModified":"2026-06-22T06:56:42.326Z","author":{"@type":"Person","name":"邻家酒肆"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20260618/","keywords":"海门回声,随想"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"海门回声 | 黑鬼","description":"黑鬼已经死了好多年了，大概在我上初中还是高中的时候。听大人们说，是在某一年的春节里，二月的天气还很冷，他像往常一样被铁链子拴在家院子前面的小屋子里，有好几天家人忘了给他送饭，便饿死了。也有人说是冻死的。我后来真的见过他——脸发青，像苔藓，不像电视剧里画着黑眼圈的饿汉。","image":"https://gitpull.cn/assets/uploads/2026/06/heigui-cover.png","datePublished":"2026-06-18T20:00:00+08:00","dateModified":"2026-06-22T06:56:42.326Z","author":{"@type":"Person","name":"邻家酒肆"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/20260618/","keywords":"海门回声,随想"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"海门回声","item":"https://gitpull.cn/tags.html#%E6%B5%B7%E9%97%A8%E5%9B%9E%E5%A3%B0"},{"@type":"ListItem","position":3,"name":"海门回声 | 黑鬼","item":"https://gitpull.cn/post/20260618/"}]}</script>
 </head>
 <body>

--- a/post/about/index.html
+++ b/post/about/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="关于小红鸡">
   <meta property="og:description" content="关于这个博客和写它的人 —— 一名做系统软件的程序员，这些年从图数据库、推荐系统一路走到大模型推理基础设施（KV 缓存 / RDMA 零拷贝 / 分布式存储），业余写点代码、读点书、记点流水账。">
-  <meta property="og:image" content="/assets/uploads/2026/05/1778491021713-cnnps5-1029bg.jpg">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/1778491021713-cnnps5-1029bg.jpg">
   <meta property="og:url" content="https://gitpull.cn/post/about/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="关于小红鸡">
   <meta name="twitter:description" content="关于这个博客和写它的人 —— 一名做系统软件的程序员，这些年从图数据库、推荐系统一路走到大模型推理基础设施（KV 缓存 / RDMA 零拷贝 / 分布式存储），业余写点代码、读点书、记点流水账。">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/1778491021713-cnnps5-1029bg.jpg">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/1778491021713-cnnps5-1029bg.jpg">
   <link rel="canonical" href="https://gitpull.cn/post/about/">
   <meta property="og:image:width" content="400">
   <meta property="og:image:height" content="533">
@@ -35,7 +35,7 @@
   <meta property="article:modified_time" content="2026-06-16T09:14:11.752Z">
   <meta property="article:author" content="Jimmy">
   <meta property="article:tag" content="杂七杂八">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"关于小红鸡","description":"关于这个博客和写它的人 —— 一名做系统软件的程序员，这些年从图数据库、推荐系统一路走到大模型推理基础设施（KV 缓存 / RDMA 零拷贝 / 分布式存储），业余写点代码、读点书、记点流水账。","image":"/assets/uploads/2026/05/1778491021713-cnnps5-1029bg.jpg","datePublished":"2026-05-11T16:40:00+08:00","dateModified":"2026-06-16T09:14:11.752Z","author":{"@type":"Person","name":"Jimmy"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/about/","keywords":"杂七杂八"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"关于小红鸡","description":"关于这个博客和写它的人 —— 一名做系统软件的程序员，这些年从图数据库、推荐系统一路走到大模型推理基础设施（KV 缓存 / RDMA 零拷贝 / 分布式存储），业余写点代码、读点书、记点流水账。","image":"https://gitpull.cn/assets/uploads/2026/05/1778491021713-cnnps5-1029bg.jpg","datePublished":"2026-05-11T16:40:00+08:00","dateModified":"2026-06-16T09:14:11.752Z","author":{"@type":"Person","name":"Jimmy"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/about/","keywords":"杂七杂八"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"杂七杂八","item":"https://gitpull.cn/tags.html#%E6%9D%82%E4%B8%83%E6%9D%82%E5%85%AB"},{"@type":"ListItem","position":3,"name":"关于小红鸡","item":"https://gitpull.cn/post/about/"}]}</script>
 </head>
 <body>

--- a/post/welcome/index.html
+++ b/post/welcome/index.html
@@ -19,7 +19,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="GitBlog：一个带伪后台的博客站点">
   <meta property="og:description" content="一个完全静态、托管在 GitHub Pages 上的博客，但带有可以在浏览器里直接写、直接发的&#39;伪后台&#39;。这篇文章记录它能做什么，相比传统方案为什么这样设计，以及如果你也想搭一个，要怎么开始。">
-  <meta property="og:image" content="/assets/uploads/2026/05/1778490605877-blwjij-image.png">
+  <meta property="og:image" content="https://gitpull.cn/assets/uploads/2026/05/1778490605877-blwjij-image.png">
   <meta property="og:url" content="https://gitpull.cn/post/welcome/">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="小红鸡">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="GitBlog：一个带伪后台的博客站点">
   <meta name="twitter:description" content="一个完全静态、托管在 GitHub Pages 上的博客，但带有可以在浏览器里直接写、直接发的&#39;伪后台&#39;。这篇文章记录它能做什么，相比传统方案为什么这样设计，以及如果你也想搭一个，要怎么开始。">
-  <meta name="twitter:image" content="/assets/uploads/2026/05/1778490605877-blwjij-image.png">
+  <meta name="twitter:image" content="https://gitpull.cn/assets/uploads/2026/05/1778490605877-blwjij-image.png">
   <link rel="canonical" href="https://gitpull.cn/post/welcome/">
   <meta property="og:image:width" content="2021">
   <meta property="og:image:height" content="1587">
@@ -37,7 +37,7 @@
   <meta property="article:tag" content="博客建站">
   <meta property="article:tag" content="教程">
   <meta property="article:tag" content="项目介绍">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"GitBlog：一个带伪后台的博客站点","description":"一个完全静态、托管在 GitHub Pages 上的博客，但带有可以在浏览器里直接写、直接发的'伪后台'。这篇文章记录它能做什么，相比传统方案为什么这样设计，以及如果你也想搭一个，要怎么开始。","image":"/assets/uploads/2026/05/1778490605877-blwjij-image.png","datePublished":"2026-05-11T16:50:00+08:00","dateModified":"2026-05-11T09:11:44.875Z","author":{"@type":"Person","name":"Jimmy"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/welcome/","keywords":"博客建站,教程,项目介绍"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"GitBlog：一个带伪后台的博客站点","description":"一个完全静态、托管在 GitHub Pages 上的博客，但带有可以在浏览器里直接写、直接发的'伪后台'。这篇文章记录它能做什么，相比传统方案为什么这样设计，以及如果你也想搭一个，要怎么开始。","image":"https://gitpull.cn/assets/uploads/2026/05/1778490605877-blwjij-image.png","datePublished":"2026-05-11T16:50:00+08:00","dateModified":"2026-05-11T09:11:44.875Z","author":{"@type":"Person","name":"Jimmy"},"publisher":{"@type":"Organization","name":"小红鸡","logo":{"@type":"ImageObject","url":"https://gitpull.cn/assets/%E7%BA%B8%E9%A3%9E%E6%9C%BA.svg"}},"mainEntityOfPage":"https://gitpull.cn/post/welcome/","keywords":"博客建站,教程,项目介绍"}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"首页","item":"https://gitpull.cn/"},{"@type":"ListItem","position":2,"name":"博客建站","item":"https://gitpull.cn/tags.html#%E5%8D%9A%E5%AE%A2%E5%BB%BA%E7%AB%99"},{"@type":"ListItem","position":3,"name":"GitBlog：一个带伪后台的博客站点","item":"https://gitpull.cn/post/welcome/"}]}</script>
 </head>
 <body>

--- a/scripts/prerender-post-html.mjs
+++ b/scripts/prerender-post-html.mjs
@@ -59,6 +59,16 @@ function publicImageUrl(url, sitePathPrefix, siteOrigin) {
   return s;
 }
 
+/** 微信 / OG 爬虫需要绝对 HTTPS 地址，相对路径会退化为默认链接图标 */
+function absolutePublicUrl(url, sitePathPrefix, siteOrigin) {
+  const path = publicImageUrl(url, sitePathPrefix, siteOrigin);
+  if (!path) return '';
+  if (/^https?:\/\//i.test(path) || path.startsWith('//')) return path;
+  const origin = String(siteOrigin || '').replace(/\/+$/, '');
+  if (!origin) return path;
+  return `${origin}${path.startsWith('/') ? path : `/${path}`}`;
+}
+
 function tagHtml(tag, href, sitePathPrefix) {
   const body = escapeHtml(tag);
   const attrs = `class="tag tag-colored" style="${tagStyle(tag)}"`;
@@ -331,13 +341,13 @@ export async function buildPrerenderedPostHtml({
   const date = post.date || fmData.date || '';
   const updated = post.updated || fmData.updated || date;
   const author = post.author || fmData.author || site.author;
-  const cover = publicImageUrl(post.cover || fmData.cover || '', sitePathPrefix, siteOrigin);
   const coverRaw = post.cover || fmData.cover || '';
+  const coverAbs = absolutePublicUrl(coverRaw, sitePathPrefix, siteOrigin);
   const tags = post.tags || fmData.tags || [];
   const summary = post.summary || fmData.summary || '';
   const canonical = post.canonical || '';
   const ogAuto = `${siteOrigin}${rootHref(sitePathPrefix, `assets/og/${encodeURIComponent(slug)}.png`)}`;
-  const image = cover || ogAuto || site.avatar || '';
+  const image = coverAbs || ogAuto || absolutePublicUrl(site.avatar || '', sitePathPrefix, siteOrigin) || '';
 
   let ogImageWidth = 0;
   let ogImageHeight = 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

分享文章到微信朋友圈时，左侧缩略图显示为默认的「链接」图标，而不是文章封面。

## 原因

微信抓取分享链接时会读取页面 HTML 中的 `og:image`。带 `cover` 字段的文章在预渲染时写入了**相对路径**（如 `/assets/uploads/2026/06/heigui-cover.png`），微信爬虫无法解析，因此回退为默认链接图标。没有封面的文章使用自动生成的 OG 图（已是 `https://gitpull.cn/...` 绝对地址），所以不受影响。

## 修复

- 在 `scripts/prerender-post-html.mjs` 新增 `absolutePublicUrl()`，将封面/头像转为绝对 HTTPS 地址后再写入 `og:image`
- 在 `assets/js/post.js` 同步修复非预渲染路径的 `setMeta()` 兜底逻辑
- 重新构建全部 67 篇预渲染文章 HTML

## 部署后

微信会缓存链接预览，部署后若仍显示旧图标，可在 [微信公众平台链接调试工具](https://mp.weixin.qq.com/debug/cgi-bin/sandbox?t=jsapisign) 重新抓取，或稍等缓存过期后再分享。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7adec158-4501-474b-9753-7a7818c87603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7adec158-4501-474b-9753-7a7818c87603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

