### PR TITLE
feat: 工具页评论区 + 摸鱼工具分享图（含二维码）

### DIFF
--- a/assets/css/tools.css
+++ b/assets/css/tools.css
@@ -575,6 +575,14 @@
 
 .tool-single-page .tool-kit-tabs { display: none; }
 
+.tool-single-page .tool-comments {
+  margin-top: 28px;
+}
+
+.tool-single-page .tool-actions {
+  margin-top: 20px;
+}
+
 .tool-kit-panel h2 {
   font-size: 22px;
   margin-bottom: 6px;

--- a/assets/js/air-conditioner.js
+++ b/assets/js/air-conditioner.js
@@ -1,6 +1,7 @@
 import { CONFIG } from './config.js';
 import { initSite } from './site.js';
 import { setMeta, setJsonLd } from './seo.js';
+import { mountToolComments } from './tool-kit-common.js';
 
 const $ = sel => document.querySelector(sel);
 
@@ -172,42 +173,7 @@ function bindControls() {
 }
 
 function renderGiscus() {
-  const g = CONFIG.giscus || {};
-  const host = $('#toolGiscus');
-  if (!host || !g.enabled) {
-    if (host) host.innerHTML = '<div class="tool-comments-hint">留言板未启用。可在后台设置里打开 giscus。</div>';
-    return;
-  }
-  if (!g.repoId || !g.categoryId) {
-    host.innerHTML = '<div class="tool-comments-hint">giscus 缺少 repoId 或 categoryId，请先在后台设置中补全。</div>';
-    return;
-  }
-  const html = document.documentElement;
-  const choice = html.dataset.themeChoice || 'auto';
-  const resolved = choice === 'auto'
-    ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-    : choice;
-  const script = document.createElement('script');
-  script.src = 'https://giscus.app/client.js';
-  script.crossOrigin = 'anonymous';
-  script.async = true;
-  const attrs = {
-    'data-repo': g.repo,
-    'data-repo-id': g.repoId,
-    'data-category': g.category,
-    'data-category-id': g.categoryId,
-    'data-mapping': 'specific',
-    'data-term': 'tool-air-conditioner',
-    'data-strict': g.strict || '0',
-    'data-reactions-enabled': g.reactionsEnabled || '1',
-    'data-emit-metadata': g.emitMetadata || '0',
-    'data-input-position': g.inputPosition || 'top',
-    'data-theme': resolved,
-    'data-lang': g.lang || 'zh-CN',
-    'data-loading': 'lazy',
-  };
-  Object.entries(attrs).forEach(([key, value]) => script.setAttribute(key, value));
-  host.appendChild(script);
+  mountToolComments('tool-air-conditioner');
 }
 
 initSite({ active: 'tools.html' });

--- a/assets/js/tool-age.js
+++ b/assets/js/tool-age.js
@@ -1,27 +1,38 @@
 import { initToolPage, $ } from './tool-kit-common.js';
+import { drawAgeShareImage, downloadCanvas, toolPageUrl } from './tool-share-image.js';
 
 initToolPage({
   title: '年龄计算器',
   description: '输入生日，计算年龄、总天数、总小时与距下次生日的天数。',
   path: 'tool-age.html',
+  commentsHint: '算出来的数字准不准？来晒晒你的年龄～',
 });
+
+let lastAge = null;
 
 function calcAge() {
   const dateVal = $('ageBirth').value;
   const timeVal = $('ageTime').value || '00:00:00';
   const el = $('ageResult');
+  const shareBtn = $('ageShare');
   if (!dateVal) {
     el.innerHTML = '<p class="tool-kit-placeholder">请选择出生日期</p>';
+    if (shareBtn) shareBtn.hidden = true;
+    lastAge = null;
     return;
   }
   const birth = new Date(`${dateVal}T${timeVal.length === 5 ? timeVal + ':00' : timeVal}`);
   if (Number.isNaN(birth.getTime())) {
     el.innerHTML = '<p class="tool-kit-error">日期无效</p>';
+    if (shareBtn) shareBtn.hidden = true;
+    lastAge = null;
     return;
   }
   const now = new Date();
   if (birth > now) {
     el.innerHTML = '<p class="tool-kit-error">出生日期不能晚于现在</p>';
+    if (shareBtn) shareBtn.hidden = true;
+    lastAge = null;
     return;
   }
 
@@ -55,8 +66,36 @@ function calcAge() {
       <div><strong>${Math.floor(livedMs / 1000).toLocaleString()}</strong><span>总秒数</span></div>
     </div>
   `;
+
+  if (shareBtn) shareBtn.hidden = false;
+  lastAge = {
+    birthLabel: `${dateVal}${timeVal !== '00:00:00' && timeVal !== '00:00' ? ' ' + timeVal : ''}`,
+    ageLine: `${years} 岁 ${months} 个月 ${days} 天`,
+    livedDays: livedDays.toLocaleString(),
+    livedHours: livedHours.toLocaleString(),
+    daysToBday,
+  };
 }
 
 $('ageBirth').max = new Date().toISOString().slice(0, 10);
 $('ageBirth').addEventListener('change', calcAge);
 $('ageTime').addEventListener('change', calcAge);
+
+$('ageShare').addEventListener('click', async () => {
+  if (!lastAge) return;
+  const btn = $('ageShare');
+  btn.disabled = true;
+  btn.textContent = '生成中…';
+  try {
+    const canvas = await drawAgeShareImage({
+      ...lastAge,
+      pageUrl: toolPageUrl('tool-age.html'),
+    });
+    downloadCanvas(canvas, `age-${Date.now()}.png`);
+  } catch (e) {
+    alert(`分享图生成失败：${e.message}`);
+  } finally {
+    btn.disabled = false;
+    btn.textContent = '生成分享图';
+  }
+});

--- a/assets/js/tool-fortune.js
+++ b/assets/js/tool-fortune.js
@@ -1,26 +1,61 @@
 import { initToolPage, $, dateSeed, pick } from './tool-kit-common.js';
 import { FORTUNE_GRADES, FORTUNE_TEXTS, FORTUNE_GOOD, FORTUNE_BAD, FORTUNE_COLORS } from './tool-fortune-data.js';
+import { drawFortuneShareImage, downloadCanvas, toolPageUrl } from './tool-share-image.js';
 
 initToolPage({
   title: '今日运势',
   description: '娱乐向今日签文，同一日期与昵称结果固定，图一乐，请勿当真。',
   path: 'tool-fortune.html',
+  commentsHint: '今日签文如何？来聊两句～',
 });
+
+let lastFortune = null;
 
 function drawFortune() {
   const name = ($('fortuneName').value || '').trim();
   const seed = dateSeed(name);
   const grade = pick(FORTUNE_GRADES, seed);
+  const level = grade.includes('吉') ? 'good' : grade === '平' ? 'mid' : 'bad';
   const card = $('fortuneResult');
   card.hidden = false;
   $('fortuneGrade').textContent = grade;
-  $('fortuneGrade').dataset.level = grade.includes('吉') ? 'good' : grade === '平' ? 'mid' : 'bad';
-  $('fortuneText').textContent = pick(FORTUNE_TEXTS, seed >> 3);
-  $('fortuneGood').textContent = `${pick(FORTUNE_GOOD, seed >> 5)}、${pick(FORTUNE_GOOD, seed >> 7)}`;
-  $('fortuneBad').textContent = `${pick(FORTUNE_BAD, seed >> 9)}、${pick(FORTUNE_BAD, seed >> 11)}`;
-  $('fortuneColor').textContent = pick(FORTUNE_COLORS, seed >> 13);
-  $('fortuneNum').textContent = String((seed % 9) + 1);
+  $('fortuneGrade').dataset.level = level;
+  const text = pick(FORTUNE_TEXTS, seed >> 3);
+  const good = `${pick(FORTUNE_GOOD, seed >> 5)}、${pick(FORTUNE_GOOD, seed >> 7)}`;
+  const bad = `${pick(FORTUNE_BAD, seed >> 9)}、${pick(FORTUNE_BAD, seed >> 11)}`;
+  const color = pick(FORTUNE_COLORS, seed >> 13);
+  const num = String((seed % 9) + 1);
+  $('fortuneText').textContent = text;
+  $('fortuneGood').textContent = good;
+  $('fortuneBad').textContent = bad;
+  $('fortuneColor').textContent = color;
+  $('fortuneNum').textContent = num;
+  lastFortune = { grade, level, text, good, bad, color, num, name };
 }
 
 $('fortuneBtn').addEventListener('click', drawFortune);
+
+const urlName = new URLSearchParams(location.search).get('name');
+if (urlName) $('fortuneName').value = urlName.slice(0, 20);
+
+$('fortuneShare').addEventListener('click', async () => {
+  if (!lastFortune) drawFortune();
+  const btn = $('fortuneShare');
+  btn.disabled = true;
+  btn.textContent = '生成中…';
+  try {
+    const name = lastFortune.name;
+    const query = name ? `name=${encodeURIComponent(name)}` : '';
+    const pageUrl = toolPageUrl('tool-fortune.html', query);
+    const canvas = await drawFortuneShareImage({ ...lastFortune, pageUrl });
+    const d = new Date();
+    downloadCanvas(canvas, `fortune-${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}.png`);
+  } catch (e) {
+    alert(`分享图生成失败：${e.message}`);
+  } finally {
+    btn.disabled = false;
+    btn.textContent = '生成分享图';
+  }
+});
+
 drawFortune();

--- a/assets/js/tool-kit-common.js
+++ b/assets/js/tool-kit-common.js
@@ -1,8 +1,9 @@
 import { initSite } from './site.js';
 import { setMeta, setJsonLd } from './seo.js';
 import { CONFIG } from './config.js';
+import { isGiscusReady, mountGiscusScript } from './giscus-embed.js';
 
-export function initToolPage({ title, description, path }) {
+export function initToolPage({ title, description, path, giscusTerm, commentsHint }) {
   initSite({ active: 'tools.html' });
   setMeta({ title, description, type: 'website' });
   const base = CONFIG.site.url || location.origin;
@@ -14,6 +15,23 @@ export function initToolPage({ title, description, path }) {
     operatingSystem: 'Any',
     url: `${base}/${path}`,
   });
+  mountToolComments(giscusTerm || path.replace(/\.html$/i, ''), commentsHint);
+}
+
+/** 工具页底部 giscus 评论区（每页独立 Discussion term） */
+export function mountToolComments(term, hint) {
+  const host = document.getElementById('toolGiscus');
+  if (!host) return;
+  const section = host.closest('.tool-comments');
+  if (section && hint) {
+    const p = section.querySelector('p');
+    if (p) p.textContent = hint;
+  }
+  if (!isGiscusReady()) {
+    host.innerHTML = '<div class="tool-comments-hint">留言板未启用。可在后台设置里打开 giscus。</div>';
+    return;
+  }
+  mountGiscusScript(host, term);
 }
 
 export function $(id) { return document.getElementById(id); }

--- a/assets/js/tool-share-image.js
+++ b/assets/js/tool-share-image.js
@@ -1,0 +1,215 @@
+// 摸鱼工具分享图：Canvas 合成 + 右下角工具页二维码
+import { CONFIG } from './config.js';
+
+let QRCodeLib = null;
+
+async function loadQR() {
+  if (QRCodeLib) return QRCodeLib;
+  QRCodeLib = await import('https://cdn.jsdelivr.net/npm/qrcode@1.5.4/+esm');
+  return QRCodeLib;
+}
+
+export function toolPageUrl(path, query = '') {
+  const base = String(CONFIG.site.url || location.origin).replace(/\/+$/, '');
+  const q = query ? (query.startsWith('?') ? query : `?${query}`) : '';
+  return `${base}/${path.replace(/^\//, '')}${q}`;
+}
+
+function roundRect(ctx, x, y, w, h, r) {
+  const rad = Math.min(r, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + rad, y);
+  ctx.arcTo(x + w, y, x + w, y + h, rad);
+  ctx.arcTo(x + w, y + h, x, y + h, rad);
+  ctx.arcTo(x, y + h, x, y, rad);
+  ctx.arcTo(x, y, x + w, y, rad);
+  ctx.closePath();
+}
+
+function wrapText(ctx, text, x, y, maxWidth, lineHeight, maxLines = 6) {
+  const chars = String(text || '').split('');
+  let line = '';
+  let cy = y;
+  let lines = 0;
+  for (let i = 0; i < chars.length; i++) {
+    const test = line + chars[i];
+    if (ctx.measureText(test).width > maxWidth && line) {
+      ctx.fillText(line, x, cy);
+      line = chars[i];
+      cy += lineHeight;
+      lines += 1;
+      if (lines >= maxLines - 1) {
+        line = line.slice(0, -1) + '…';
+        break;
+      }
+    } else {
+      line = test;
+    }
+  }
+  if (line) ctx.fillText(line, x, cy);
+  return cy + lineHeight;
+}
+
+async function drawQr(ctx, url, x, y, size) {
+  const QRCode = await loadQR();
+  const qrCanvas = document.createElement('canvas');
+  await QRCode.toCanvas(qrCanvas, url, {
+    width: size,
+    margin: 1,
+    errorCorrectionLevel: 'M',
+    color: { dark: '#1a1a1a', light: '#ffffff' },
+  });
+  ctx.drawImage(qrCanvas, x, y, size, size);
+}
+
+async function drawQrBlock(ctx, url, label, W, H, qrSize = 132) {
+  const pad = 40;
+  const blockW = qrSize + 24;
+  const blockH = qrSize + 52;
+  const bx = W - blockW - pad;
+  const by = H - blockH - pad;
+  ctx.fillStyle = 'rgba(255,255,255,0.92)';
+  roundRect(ctx, bx, by, blockW, blockH, 14);
+  ctx.fill();
+  ctx.strokeStyle = 'rgba(0,0,0,0.06)';
+  ctx.lineWidth = 1;
+  ctx.stroke();
+  await drawQr(ctx, url, bx + 12, by + 12, qrSize);
+  ctx.fillStyle = '#888';
+  ctx.font = '18px system-ui, -apple-system, "PingFang SC", "Microsoft YaHei", sans-serif';
+  ctx.textAlign = 'center';
+  ctx.fillText(label, bx + blockW / 2, by + qrSize + 36);
+  ctx.textAlign = 'left';
+}
+
+export function downloadCanvas(canvas, filename) {
+  const a = document.createElement('a');
+  a.download = filename;
+  a.href = canvas.toDataURL('image/png');
+  a.click();
+}
+
+const FONT = 'system-ui, -apple-system, "PingFang SC", "Microsoft YaHei", sans-serif';
+
+/** 今日运势分享图 */
+export async function drawFortuneShareImage({ grade, level, text, good, bad, color, num, name, pageUrl }) {
+  const W = 750;
+  const H = 1100;
+  const canvas = document.createElement('canvas');
+  canvas.width = W;
+  canvas.height = H;
+  const ctx = canvas.getContext('2d');
+
+  const grad = ctx.createLinearGradient(0, 0, W, H);
+  grad.addColorStop(0, '#fff8f6');
+  grad.addColorStop(0.5, '#fff0eb');
+  grad.addColorStop(1, '#ffe4dc');
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, W, H);
+
+  ctx.fillStyle = '#ea6f5a';
+  ctx.font = `bold 36px ${FONT}`;
+  ctx.fillText('今日运势', 48, 72);
+
+  const d = new Date();
+  const dateStr = `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`;
+  ctx.fillStyle = '#888';
+  ctx.font = `22px ${FONT}`;
+  ctx.fillText(name ? `${dateStr} · ${name}` : dateStr, 48, 112);
+
+  const palettes = {
+    good: ['#e8f8ee', '#1e7a43'],
+    mid: ['#fff4d8', '#936018'],
+    bad: ['#fce8f3', '#a33b72'],
+  };
+  const [bg, fg] = palettes[level] || palettes.mid;
+  ctx.fillStyle = bg;
+  roundRect(ctx, 48, 140, Math.max(100, ctx.measureText(grade).width + 40), 52, 26);
+  ctx.fill();
+  ctx.fillStyle = fg;
+  ctx.font = `bold 28px ${FONT}`;
+  ctx.textAlign = 'center';
+  ctx.fillText(grade, 48 + Math.max(100, ctx.measureText(grade).width + 40) / 2, 176);
+  ctx.textAlign = 'left';
+
+  ctx.fillStyle = '#222';
+  ctx.font = `32px ${FONT}`;
+  wrapText(ctx, text, 48, 240, W - 96, 48, 5);
+
+  const meta = [
+    ['宜', good],
+    ['忌', bad],
+    ['幸运色', color],
+    ['幸运数字', String(num)],
+  ];
+  let y = 480;
+  ctx.font = `26px ${FONT}`;
+  for (const [label, val] of meta) {
+    ctx.fillStyle = '#aaa';
+    ctx.fillText(label, 48, y);
+    ctx.fillStyle = '#333';
+    ctx.fillText(val, 110, y);
+    y += 48;
+  }
+
+  ctx.fillStyle = '#bbb';
+  ctx.font = `20px ${FONT}`;
+  ctx.fillText('仅供娱乐，请勿当真', 48, H - 200);
+
+  await drawQrBlock(ctx, pageUrl, '扫码抽签', W, H);
+  return canvas;
+}
+
+/** 年龄计算器分享图 */
+export async function drawAgeShareImage({ birthLabel, ageLine, livedDays, livedHours, daysToBday, pageUrl }) {
+  const W = 750;
+  const H = 1000;
+  const canvas = document.createElement('canvas');
+  canvas.width = W;
+  canvas.height = H;
+  const ctx = canvas.getContext('2d');
+
+  const grad = ctx.createLinearGradient(0, 0, W, H);
+  grad.addColorStop(0, '#f6fbff');
+  grad.addColorStop(1, '#e8f1ff');
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, W, H);
+
+  ctx.fillStyle = '#1e5aa8';
+  ctx.font = `bold 36px ${FONT}`;
+  ctx.fillText('年龄计算器', 48, 72);
+
+  ctx.fillStyle = '#888';
+  ctx.font = `22px ${FONT}`;
+  ctx.fillText(`出生：${birthLabel}`, 48, 112);
+
+  ctx.fillStyle = '#222';
+  ctx.font = `bold 52px ${FONT}`;
+  ctx.fillText(ageLine, 48, 200);
+
+  const stats = [
+    ['总天数', livedDays],
+    ['总小时', livedHours],
+    ['距下次生日', `${daysToBday} 天`],
+  ];
+  let y = 280;
+  for (const [label, val] of stats) {
+    ctx.fillStyle = '#fff';
+    roundRect(ctx, 48, y, W - 96, 100, 16);
+    ctx.fill();
+    ctx.fillStyle = '#888';
+    ctx.font = `22px ${FONT}`;
+    ctx.fillText(label, 72, y + 38);
+    ctx.fillStyle = '#1e5aa8';
+    ctx.font = `bold 36px ${FONT}`;
+    ctx.fillText(String(val), 72, y + 78);
+    y += 120;
+  }
+
+  ctx.fillStyle = '#bbb';
+  ctx.font = `20px ${FONT}`;
+  ctx.fillText('gitpull.cn 工具箱', 48, H - 200);
+
+  await drawQrBlock(ctx, pageUrl, '扫码计算', W, H);
+  return canvas;
+}

--- a/scripts/generate-tool-pages.mjs
+++ b/scripts/generate-tool-pages.mjs
@@ -14,11 +14,15 @@ const PAGES = [
     h1: '年龄计算器',
     lead: '输入生日，看看你已经在这个星球上待了多久。',
     script: 'tool-age.js',
+    commentsHint: '算出来的数字准不准？来晒晒你的年龄～',
     body: `
       <section class="tool-kit-panel is-active">
         <div class="tool-kit-form">
           <label>出生日期 <input type="date" id="ageBirth" max="9999-12-31"></label>
           <label>出生时间（可选） <input type="time" id="ageTime" step="1"></label>
+        </div>
+        <div class="tool-kit-toolbar">
+          <button type="button" class="tool-kit-btn is-ghost" id="ageShare" hidden>生成分享图</button>
         </div>
         <div class="tool-kit-stats" id="ageResult">
           <p class="tool-kit-placeholder">请选择出生日期</p>
@@ -33,11 +37,13 @@ const PAGES = [
     h1: '今日运势',
     lead: '娱乐向，图一乐。同一日期 + 昵称会得到相同结果。',
     script: 'tool-fortune.js',
+    commentsHint: '今日签文如何？来聊两句～',
     body: `
       <section class="tool-kit-panel is-active">
         <div class="tool-kit-form tool-kit-form-inline">
           <label>昵称（可选） <input type="text" id="fortuneName" placeholder="留空也行" maxlength="20"></label>
           <button type="button" class="tool-kit-btn" id="fortuneBtn">再抽一次</button>
+          <button type="button" class="tool-kit-btn is-ghost" id="fortuneShare">生成分享图</button>
         </div>
         <article class="fortune-card" id="fortuneResult" hidden>
           <div class="fortune-grade" id="fortuneGrade"></div>

--- a/scripts/tool-page-shell.mjs
+++ b/scripts/tool-page-shell.mjs
@@ -1,6 +1,8 @@
 /** 生成独立工具页 HTML 壳（构建脚本 / 手工维护共用模板） */
-export function toolPageHtml({ title, description, eyebrow, h1, lead, body, script }) {
+export function toolPageHtml({ title, description, eyebrow, h1, lead, body, script, commentsHint }) {
   const v = '20260622140000';
+  const giscusTerm = String(script || '').replace(/\.js$/i, '');
+  const hint = commentsHint || '使用体验、bug 反馈或建议，欢迎留言。';
   return `<!DOCTYPE html>
 <html lang="zh-CN">
 <head>
@@ -29,11 +31,17 @@ export function toolPageHtml({ title, description, eyebrow, h1, lead, body, scri
     <div class="tool-kit-panels">
       ${body}
     </div>
+    <section class="tool-comments" id="toolComments">
+      <h2>评论</h2>
+      <p>${hint}</p>
+      <div id="toolGiscus"></div>
+    </section>
     <section class="tool-actions">
       <a class="btn-home" href="./">返回首页</a>
       <a class="btn-ghost" href="tools.html">查看工具箱</a>
     </section>
   </main>
+  <script type="application/json" id="toolPageMeta">${JSON.stringify({ giscusTerm })}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
   <script type="module" src="assets/js/${script}?v=${v}"></script>

--- a/tool-age.html
+++ b/tool-age.html
@@ -30,16 +30,25 @@
           <label>出生日期 <input type="date" id="ageBirth" max="9999-12-31"></label>
           <label>出生时间（可选） <input type="time" id="ageTime" step="1"></label>
         </div>
+        <div class="tool-kit-toolbar">
+          <button type="button" class="tool-kit-btn is-ghost" id="ageShare" hidden>生成分享图</button>
+        </div>
         <div class="tool-kit-stats" id="ageResult">
           <p class="tool-kit-placeholder">请选择出生日期</p>
         </div>
       </section>
     </div>
+    <section class="tool-comments" id="toolComments">
+      <h2>评论</h2>
+      <p>算出来的数字准不准？来晒晒你的年龄～</p>
+      <div id="toolGiscus"></div>
+    </section>
     <section class="tool-actions">
       <a class="btn-home" href="./">返回首页</a>
       <a class="btn-ghost" href="tools.html">查看工具箱</a>
     </section>
   </main>
+  <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-age"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
   <script type="module" src="assets/js/tool-age.js?v=20260622140000"></script>

--- a/tool-codec.html
+++ b/tool-codec.html
@@ -43,11 +43,17 @@
         <p class="tool-kit-status" id="codecStatus"></p>
       </section>
     </div>
+    <section class="tool-comments" id="toolComments">
+      <h2>评论</h2>
+      <p>使用体验、bug 反馈或建议，欢迎留言。</p>
+      <div id="toolGiscus"></div>
+    </section>
     <section class="tool-actions">
       <a class="btn-home" href="./">返回首页</a>
       <a class="btn-ghost" href="tools.html">查看工具箱</a>
     </section>
   </main>
+  <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-codec"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
   <script type="module" src="assets/js/tool-codec.js?v=20260622140000"></script>

--- a/tool-fortune.html
+++ b/tool-fortune.html
@@ -29,6 +29,7 @@
         <div class="tool-kit-form tool-kit-form-inline">
           <label>昵称（可选） <input type="text" id="fortuneName" placeholder="留空也行" maxlength="20"></label>
           <button type="button" class="tool-kit-btn" id="fortuneBtn">再抽一次</button>
+          <button type="button" class="tool-kit-btn is-ghost" id="fortuneShare">生成分享图</button>
         </div>
         <article class="fortune-card" id="fortuneResult" hidden>
           <div class="fortune-grade" id="fortuneGrade"></div>
@@ -43,11 +44,17 @@
         </article>
       </section>
     </div>
+    <section class="tool-comments" id="toolComments">
+      <h2>评论</h2>
+      <p>今日签文如何？来聊两句～</p>
+      <div id="toolGiscus"></div>
+    </section>
     <section class="tool-actions">
       <a class="btn-home" href="./">返回首页</a>
       <a class="btn-ghost" href="tools.html">查看工具箱</a>
     </section>
   </main>
+  <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-fortune"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
   <script type="module" src="assets/js/tool-fortune.js?v=20260622140000"></script>

--- a/tool-image.html
+++ b/tool-image.html
@@ -49,11 +49,17 @@
         <p class="tool-kit-status" id="imgStatus"></p>
       </section>
     </div>
+    <section class="tool-comments" id="toolComments">
+      <h2>评论</h2>
+      <p>使用体验、bug 反馈或建议，欢迎留言。</p>
+      <div id="toolGiscus"></div>
+    </section>
     <section class="tool-actions">
       <a class="btn-home" href="./">返回首页</a>
       <a class="btn-ghost" href="tools.html">查看工具箱</a>
     </section>
   </main>
+  <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-image"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
   <script type="module" src="assets/js/tool-image.js?v=20260622140000"></script>

--- a/tool-json.html
+++ b/tool-json.html
@@ -36,11 +36,17 @@
         <p class="tool-kit-status" id="jsonStatus"></p>
       </section>
     </div>
+    <section class="tool-comments" id="toolComments">
+      <h2>评论</h2>
+      <p>使用体验、bug 反馈或建议，欢迎留言。</p>
+      <div id="toolGiscus"></div>
+    </section>
     <section class="tool-actions">
       <a class="btn-home" href="./">返回首页</a>
       <a class="btn-ghost" href="tools.html">查看工具箱</a>
     </section>
   </main>
+  <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-json"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
   <script type="module" src="assets/js/tool-json.js?v=20260622140000"></script>

--- a/tool-network.html
+++ b/tool-network.html
@@ -37,11 +37,17 @@
         </dl>
       </section>
     </div>
+    <section class="tool-comments" id="toolComments">
+      <h2>评论</h2>
+      <p>使用体验、bug 反馈或建议，欢迎留言。</p>
+      <div id="toolGiscus"></div>
+    </section>
     <section class="tool-actions">
       <a class="btn-home" href="./">返回首页</a>
       <a class="btn-ghost" href="tools.html">查看工具箱</a>
     </section>
   </main>
+  <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-network"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
   <script type="module" src="assets/js/tool-network.js?v=20260622140000"></script>

--- a/tool-qrcode.html
+++ b/tool-qrcode.html
@@ -39,11 +39,17 @@
         <p class="tool-kit-status" id="qrStatus"></p>
       </section>
     </div>
+    <section class="tool-comments" id="toolComments">
+      <h2>评论</h2>
+      <p>使用体验、bug 反馈或建议，欢迎留言。</p>
+      <div id="toolGiscus"></div>
+    </section>
     <section class="tool-actions">
       <a class="btn-home" href="./">返回首页</a>
       <a class="btn-ghost" href="tools.html">查看工具箱</a>
     </section>
   </main>
+  <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-qrcode"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
   <script type="module" src="assets/js/tool-qrcode.js?v=20260622140000"></script>

--- a/tool-regex.html
+++ b/tool-regex.html
@@ -37,11 +37,17 @@
         <div class="tool-kit-output" id="regexMatches"></div>
       </section>
     </div>
+    <section class="tool-comments" id="toolComments">
+      <h2>评论</h2>
+      <p>使用体验、bug 反馈或建议，欢迎留言。</p>
+      <div id="toolGiscus"></div>
+    </section>
     <section class="tool-actions">
       <a class="btn-home" href="./">返回首页</a>
       <a class="btn-ghost" href="tools.html">查看工具箱</a>
     </section>
   </main>
+  <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-regex"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
   <script type="module" src="assets/js/tool-regex.js?v=20260622140000"></script>

--- a/tool-timestamp.html
+++ b/tool-timestamp.html
@@ -51,11 +51,17 @@
         <div class="tool-kit-output" id="tsResult"></div>
       </section>
     </div>
+    <section class="tool-comments" id="toolComments">
+      <h2>评论</h2>
+      <p>使用体验、bug 反馈或建议，欢迎留言。</p>
+      <div id="toolGiscus"></div>
+    </section>
     <section class="tool-actions">
       <a class="btn-home" href="./">返回首页</a>
       <a class="btn-ghost" href="tools.html">查看工具箱</a>
     </section>
   </main>
+  <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-timestamp"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
   <script type="module" src="assets/js/tool-timestamp.js?v=20260622140000"></script>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 功能

### 1. 工具页评论区
- 9 个独立工具页底部均加入 giscus 评论区
- 每页使用独立 `data-term`（如 `tool-fortune`、`tool-json`），互不干扰
- `initToolPage()` 自动挂载评论，无需各工具 JS 重复代码

### 2. 摸鱼工具分享图
- **今日运势**：「生成分享图」按钮，输出签文卡片 PNG，右下角带工具页二维码
- **年龄计算器**：计算完成后可生成分享图，同样右下角二维码
- 分享图二维码指向对应工具页；运势图若填写昵称，二维码带 `?name=` 参数，扫码打开后自动填入

### 实现细节
- 新增 `assets/js/tool-share-image.js`：Canvas 合成 + `qrcode` ESM 生成二维码
- 更新 `scripts/tool-page-shell.mjs` 模板与 `npm run tools:pages` 生成逻辑
- 小空调页复用 `mountToolComments()` 统一 giscus 逻辑

## 使用

部署后打开任意工具页，滚动到底部即可留言。运势/年龄页点击「生成分享图」下载 PNG 后可直接发朋友圈。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7adec158-4501-474b-9753-7a7818c87603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7adec158-4501-474b-9753-7a7818c87603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

