### PR TITLE
fix: 所有工具页 giscus 评论区立即加载

### DIFF
--- a/assets/css/tools.css
+++ b/assets/css/tools.css
@@ -442,6 +442,16 @@
   margin-bottom: 18px;
 }
 
+#toolGiscus {
+  min-height: 120px;
+}
+
+.tool-comments-loading {
+  color: var(--text-tertiary);
+  font-size: 14px;
+  margin: 0 0 12px;
+}
+
 @keyframes ventSwing {
   0%, 100% { transform: rotateX(0deg); }
   50% { transform: rotateX(18deg); }

--- a/assets/js/giscus-embed.js
+++ b/assets/js/giscus-embed.js
@@ -21,7 +21,7 @@ export function notesFeedTerm() {
  * @param {string} term 文章 slug，或随笔聚合用的 notesFeedTerm()
  * @returns {boolean} 是否已注入脚本
  */
-export function mountGiscusScript(targetEl, term) {
+export function mountGiscusScript(targetEl, term, opts = {}) {
   if (!targetEl || !term) return false;
   const g = CONFIG.giscus;
   if (!g || !g.enabled) {
@@ -72,7 +72,7 @@ export function mountGiscusScript(targetEl, term) {
     'data-input-position': g.inputPosition || 'top',
     'data-theme': resolved,
     'data-lang': g.lang || 'zh-CN',
-    'data-loading': 'lazy',
+    'data-loading': opts.loading || 'lazy',
   };
   if (dataTerm) attrs['data-term'] = dataTerm;
   Object.entries(attrs).forEach(([k, v]) => s.setAttribute(k, v));

--- a/assets/js/tool-kit-common.js
+++ b/assets/js/tool-kit-common.js
@@ -31,7 +31,8 @@ export function mountToolComments(term, hint) {
     host.innerHTML = '<div class="tool-comments-hint">留言板未启用。可在后台设置里打开 giscus。</div>';
     return;
   }
-  mountGiscusScript(host, term);
+  host.innerHTML = '<p class="tool-comments-loading" aria-live="polite">评论加载中…</p>';
+  mountGiscusScript(host, term, { loading: 'eager' });
 }
 
 export function $(id) { return document.getElementById(id); }

--- a/assets/js/tool-share-image.js
+++ b/assets/js/tool-share-image.js
@@ -134,7 +134,7 @@ export async function drawFortuneShareImage({ grade, level, text, good, bad, col
 
   ctx.fillStyle = '#222';
   ctx.font = `32px ${FONT}`;
-  wrapText(ctx, text, 48, 240, W - 96, 48, 5);
+  const textEndY = wrapText(ctx, text, 48, 240, W - 96, 48, 5);
 
   const meta = [
     ['宜', good],
@@ -142,13 +142,17 @@ export async function drawFortuneShareImage({ grade, level, text, good, bad, col
     ['幸运色', color],
     ['幸运数字', String(num)],
   ];
-  let y = 480;
+  const labelX = 48;
+  const valueGap = 20;
   ctx.font = `26px ${FONT}`;
+  const labelWidth = Math.max(...meta.map(([label]) => ctx.measureText(label).width));
+  const valueX = labelX + labelWidth + valueGap;
+  let y = Math.max(textEndY + 36, 460);
   for (const [label, val] of meta) {
     ctx.fillStyle = '#aaa';
-    ctx.fillText(label, 48, y);
+    ctx.fillText(label, labelX, y);
     ctx.fillStyle = '#333';
-    ctx.fillText(val, 110, y);
+    ctx.fillText(val, valueX, y);
     y += 48;
   }
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync, rmSync
 import { join, basename, extname } from 'node:path';
 import sharp from 'sharp';
 import { buildPrerenderedPostHtml } from './prerender-post-html.mjs';
+import { TOOL_HTML_FILES } from './generate-tool-pages.mjs';
 
 // 从 config.js 中提取 site.url / site.title 等（粗暴正则即可，不引入打包器）
 const cfgRaw = readFileSync('assets/js/config.js', 'utf8');
@@ -716,3 +717,4 @@ function injectHomeSeo() {
   console.log(`index.html 已注入静态 SEO + 首页列表（${latestForHome.length} 篇）`);
 }
 injectHomeSeo();
+console.log(`tool/*.html 已就绪（${TOOL_HTML_FILES.length} 个工具页，含评论区）`);

--- a/scripts/generate-tool-pages.mjs
+++ b/scripts/generate-tool-pages.mjs
@@ -3,7 +3,7 @@
 import { writeFileSync } from 'node:fs';
 import { toolPageHtml } from './tool-page-shell.mjs';
 
-const V = '20260622140000';
+const V = '20260622180000';
 
 const PAGES = [
   {

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // 与 ?v=VERSION 的 cache-busting 协同：CACHE_NAME 用 release VERSION 区分批次
 // ============================================================================
 
-const SW_VERSION = '20260622140000';
+const SW_VERSION = '20260622180000';
 const STATIC_CACHE = `static-${SW_VERSION}`;
 const PAGE_CACHE = `pages-${SW_VERSION}`;
 const RUNTIME_CACHE = `runtime-${SW_VERSION}`;

--- a/tool-age.html
+++ b/tool-age.html
@@ -7,8 +7,8 @@
   <title>年龄计算器 · 加载中…</title>
   <meta name="description" content="输入生日，计算年龄、总天数、总小时与距下次生日的天数。">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
-  <link rel="stylesheet" href="assets/css/common.css?v=20260622140000">
-  <link rel="stylesheet" href="assets/css/tools.css?v=20260622140000">
+  <link rel="stylesheet" href="assets/css/common.css?v=20260622180000">
+  <link rel="stylesheet" href="assets/css/tools.css?v=20260622180000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
@@ -51,6 +51,6 @@
   <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-age"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
-  <script type="module" src="assets/js/tool-age.js?v=20260622140000"></script>
+  <script type="module" src="assets/js/tool-age.js?v=20260622180000"></script>
 </body>
 </html>

--- a/tool-codec.html
+++ b/tool-codec.html
@@ -7,8 +7,8 @@
   <title>Base64 / URL 编解码 · 加载中…</title>
   <meta name="description" content="Base64 与 URL 编码、解码，支持交换输入输出，浏览器本地处理。">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
-  <link rel="stylesheet" href="assets/css/common.css?v=20260622140000">
-  <link rel="stylesheet" href="assets/css/tools.css?v=20260622140000">
+  <link rel="stylesheet" href="assets/css/common.css?v=20260622180000">
+  <link rel="stylesheet" href="assets/css/tools.css?v=20260622180000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
@@ -56,6 +56,6 @@
   <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-codec"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
-  <script type="module" src="assets/js/tool-codec.js?v=20260622140000"></script>
+  <script type="module" src="assets/js/tool-codec.js?v=20260622180000"></script>
 </body>
 </html>

--- a/tool-fortune.html
+++ b/tool-fortune.html
@@ -7,8 +7,8 @@
   <title>今日运势 · 加载中…</title>
   <meta name="description" content="娱乐向今日签文，同一日期与昵称结果固定，图一乐，请勿当真。">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
-  <link rel="stylesheet" href="assets/css/common.css?v=20260622140000">
-  <link rel="stylesheet" href="assets/css/tools.css?v=20260622140000">
+  <link rel="stylesheet" href="assets/css/common.css?v=20260622180000">
+  <link rel="stylesheet" href="assets/css/tools.css?v=20260622180000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
@@ -57,6 +57,6 @@
   <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-fortune"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
-  <script type="module" src="assets/js/tool-fortune.js?v=20260622140000"></script>
+  <script type="module" src="assets/js/tool-fortune.js?v=20260622180000"></script>
 </body>
 </html>

--- a/tool-image.html
+++ b/tool-image.html
@@ -7,8 +7,8 @@
   <title>图片压缩 / WebP 转换 · 加载中…</title>
   <meta name="description" content="浏览器本地压缩图片，输出 WebP、JPEG 或 PNG，可调质量与最大宽度。">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
-  <link rel="stylesheet" href="assets/css/common.css?v=20260622140000">
-  <link rel="stylesheet" href="assets/css/tools.css?v=20260622140000">
+  <link rel="stylesheet" href="assets/css/common.css?v=20260622180000">
+  <link rel="stylesheet" href="assets/css/tools.css?v=20260622180000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
@@ -62,6 +62,6 @@
   <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-image"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
-  <script type="module" src="assets/js/tool-image.js?v=20260622140000"></script>
+  <script type="module" src="assets/js/tool-image.js?v=20260622180000"></script>
 </body>
 </html>

--- a/tool-json.html
+++ b/tool-json.html
@@ -7,8 +7,8 @@
   <title>JSON 格式化 · 加载中…</title>
   <meta name="description" content="在线 JSON 格式化、压缩、校验与复制，浏览器本地处理。">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
-  <link rel="stylesheet" href="assets/css/common.css?v=20260622140000">
-  <link rel="stylesheet" href="assets/css/tools.css?v=20260622140000">
+  <link rel="stylesheet" href="assets/css/common.css?v=20260622180000">
+  <link rel="stylesheet" href="assets/css/tools.css?v=20260622180000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
@@ -49,6 +49,6 @@
   <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-json"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
-  <script type="module" src="assets/js/tool-json.js?v=20260622140000"></script>
+  <script type="module" src="assets/js/tool-json.js?v=20260622180000"></script>
 </body>
 </html>

--- a/tool-network.html
+++ b/tool-network.html
@@ -7,8 +7,8 @@
   <title>网络与浏览器信息 · 加载中…</title>
   <meta name="description" content="查看公网 IP、运营商、城市与浏览器、屏幕、UA 等信息。">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
-  <link rel="stylesheet" href="assets/css/common.css?v=20260622140000">
-  <link rel="stylesheet" href="assets/css/tools.css?v=20260622140000">
+  <link rel="stylesheet" href="assets/css/common.css?v=20260622180000">
+  <link rel="stylesheet" href="assets/css/tools.css?v=20260622180000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
@@ -50,6 +50,6 @@
   <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-network"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
-  <script type="module" src="assets/js/tool-network.js?v=20260622140000"></script>
+  <script type="module" src="assets/js/tool-network.js?v=20260622180000"></script>
 </body>
 </html>

--- a/tool-qrcode.html
+++ b/tool-qrcode.html
@@ -7,8 +7,8 @@
   <title>二维码生成 · 加载中…</title>
   <meta name="description" content="文本或链接一键生成二维码 PNG，支持下载。">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
-  <link rel="stylesheet" href="assets/css/common.css?v=20260622140000">
-  <link rel="stylesheet" href="assets/css/tools.css?v=20260622140000">
+  <link rel="stylesheet" href="assets/css/common.css?v=20260622180000">
+  <link rel="stylesheet" href="assets/css/tools.css?v=20260622180000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
@@ -52,6 +52,6 @@
   <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-qrcode"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
-  <script type="module" src="assets/js/tool-qrcode.js?v=20260622140000"></script>
+  <script type="module" src="assets/js/tool-qrcode.js?v=20260622180000"></script>
 </body>
 </html>

--- a/tool-regex.html
+++ b/tool-regex.html
@@ -7,8 +7,8 @@
   <title>正则测试 · 加载中…</title>
   <meta name="description" content="在线正则表达式测试，实时高亮匹配并列出所有 match。">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
-  <link rel="stylesheet" href="assets/css/common.css?v=20260622140000">
-  <link rel="stylesheet" href="assets/css/tools.css?v=20260622140000">
+  <link rel="stylesheet" href="assets/css/common.css?v=20260622180000">
+  <link rel="stylesheet" href="assets/css/tools.css?v=20260622180000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
@@ -50,6 +50,6 @@
   <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-regex"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
-  <script type="module" src="assets/js/tool-regex.js?v=20260622140000"></script>
+  <script type="module" src="assets/js/tool-regex.js?v=20260622180000"></script>
 </body>
 </html>

--- a/tool-timestamp.html
+++ b/tool-timestamp.html
@@ -7,8 +7,8 @@
   <title>时间戳转换 · 加载中…</title>
   <meta name="description" content="Unix 时间戳（秒/毫秒）与本地日期时间互转，支持一键取当前时间。">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
-  <link rel="stylesheet" href="assets/css/common.css?v=20260622140000">
-  <link rel="stylesheet" href="assets/css/tools.css?v=20260622140000">
+  <link rel="stylesheet" href="assets/css/common.css?v=20260622180000">
+  <link rel="stylesheet" href="assets/css/tools.css?v=20260622180000">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#ea6f5a">
@@ -64,6 +64,6 @@
   <script type="application/json" id="toolPageMeta">{"giscusTerm":"tool-timestamp"}</script>
   <div id="site-footer"></div>
   <div id="site-overlays"></div>
-  <script type="module" src="assets/js/tool-timestamp.js?v=20260622140000"></script>
+  <script type="module" src="assets/js/tool-timestamp.js?v=20260622180000"></script>
 </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

用户反馈只有运势页能看到评论区，其他工具页没有。

实际上 9 个工具页 HTML 里**都已有**评论区结构（PR #62），但 giscus 默认 `lazy` 加载：页面较长时（如 JSON 格式化的大 textarea），评论框在视口外，不滚动就不会加载，看起来像「没有评论区」。运势页内容较短，评论框更容易进入视口，所以更容易看到。

## 修复

- 工具页 giscus 改为 **eager** 立即加载
- 增加「评论加载中…」占位与 `#toolGiscus` 最小高度
- 升级 Service Worker 版本，清掉可能缓存的旧工具页 HTML
- `npm run build` 时自动执行 `tools:pages`，保证构建产物含评论区

## 验证

打开 `tool-json.html` 等任意工具页，无需滚动到底部也应能看到 giscus 评论框（或「评论加载中…」后加载完成）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7adec158-4501-474b-9753-7a7818c87603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7adec158-4501-474b-9753-7a7818c87603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

