### PR TITLE
feat: PC 端右下角装饰图（仅宽屏显示）

### DIFF
--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -962,3 +962,40 @@ mark { background: var(--highlight); color: var(--text-main); padding: 0 2px; bo
 @media (max-width: 420px) {
   .preset-picker-grid { grid-template-columns: 1fr; }
 }
+
+/* PC 端右下角装饰图（仅宽屏显示，不挡点击） */
+.site-pc-corner-decor {
+  display: none;
+}
+
+@media (min-width: 821px) {
+  .site-pc-corner-decor {
+    display: block;
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    z-index: 2;
+    pointer-events: none;
+    user-select: none;
+    max-width: min(300px, 26vw);
+    line-height: 0;
+  }
+
+  .site-pc-corner-decor img {
+    width: 100%;
+    height: auto;
+    max-height: min(520px, 72vh);
+    object-fit: contain;
+    object-position: bottom right;
+    opacity: 0.95;
+  }
+
+  :root[data-mode="dark"] .site-pc-corner-decor img,
+  :root[data-theme="dark"] .site-pc-corner-decor img {
+    opacity: 0.88;
+  }
+}
+
+@media print {
+  .site-pc-corner-decor { display: none !important; }
+}

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -130,5 +130,9 @@ export const CONFIG = {
     wechat: "",
     alipay: "",
     paypal: ""
+  },
+  decor: {
+    enabled: true,
+    pcCornerImage: "assets/uploads/2026/06/pc-corner-mascot.png"
   }
 };

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -531,6 +531,24 @@ function injectAnalytics() {
   });
 }
 
+function mountPcCornerDecor() {
+  const decor = CONFIG.decor || {};
+  if (!decor.enabled || !decor.pcCornerImage) return;
+  if (location.pathname.includes('/admin/')) return;
+  if (document.getElementById('site-pc-corner-decor')) return;
+  const wrap = document.createElement('div');
+  wrap.id = 'site-pc-corner-decor';
+  wrap.className = 'site-pc-corner-decor';
+  wrap.setAttribute('aria-hidden', 'true');
+  const img = document.createElement('img');
+  img.src = rootPath(String(decor.pcCornerImage).replace(/^\/+/, ''));
+  img.alt = '';
+  img.decoding = 'async';
+  img.loading = 'lazy';
+  wrap.appendChild(img);
+  document.body.appendChild(wrap);
+}
+
 export function initSite({ active = '', skipDuplicateSitePv = false } = {}) {
   initTheme();
   applyFavicon();
@@ -549,6 +567,7 @@ export function initSite({ active = '', skipDuplicateSitePv = false } = {}) {
   if ($('#year')) $('#year').textContent = new Date().getFullYear();
   injectAnalytics();
   initPageviews();
+  mountPcCornerDecor();
   registerServiceWorker();
 }
 

--- a/scripts/release-template/config.js
+++ b/scripts/release-template/config.js
@@ -118,5 +118,9 @@ export const CONFIG = {
     wechat: "",           // 微信收款码图片 URL
     alipay: "",           // 支付宝收款码图片 URL
     paypal: ""            // PayPal 链接（如 https://paypal.me/xxx）
+  },
+  decor: {
+    enabled: false,
+    pcCornerImage: ""     // PC 端右下角装饰图，如 assets/uploads/2026/06/pc-corner-mascot.png
   }
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

在 PC 端（宽屏 ≥821px）右下角固定显示一张装饰图，移动端与打印时不显示，且不拦截点击。

## Changes

- `assets/js/config.js`：新增 `decor.enabled` / `decor.pcCornerImage` 配置
- `assets/js/site.js`：`mountPcCornerDecor()` 在 `initSite()` 中挂载（后台 `/admin/` 跳过）
- `assets/css/common.css`：`.site-pc-corner-decor` 固定右下角、`pointer-events: none`、暗色模式略降透明度
- `scripts/release-template/config.js`：同步 decor 配置模板

## Image required

合并后请将装饰图放到：

`assets/uploads/2026/06/pc-corner-mascot.png`

或在 `config.js` 中修改 `decor.pcCornerImage` 为实际上传路径。关闭装饰可设 `decor.enabled: false`。

## Test plan

- [ ] PC 宽屏：右下角可见装饰图，不挡按钮/链接
- [ ] 移动端（≤820px）：不显示
- [ ] 后台 admin 页面：不显示
- [ ] 暗色模式：透明度正常
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7adec158-4501-474b-9753-7a7818c87603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7adec158-4501-474b-9753-7a7818c87603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

