### PR TITLE
feat: 导航栏添加小助手外链，移除标签入口

### DIFF
--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -28,10 +28,6 @@ export const CONFIG = {
         href: "./"
       },
       {
-        name: "标签",
-        href: "tags.html"
-      },
-      {
         name: "归档",
         href: "archives.html"
       },
@@ -50,6 +46,10 @@ export const CONFIG = {
       {
         name: "关于",
         href: "post/about/"
+      },
+      {
+        name: "小助手",
+        href: "https://yuanqi.tencent.com/webim/#/chat/RhQLBj?appid=2068988279428657408"
       }
     ],
     social: {

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -224,17 +224,26 @@ function navResolveHref(href) {
   return rootPath(h);
 }
 
+function isExternalNavHref(href) {
+  const h = String(href || '').trim();
+  return /^https?:\/\//i.test(h) || h.startsWith('//');
+}
+
+function navLinkAttrs(href) {
+  return isExternalNavHref(href) ? ' target="_blank" rel="noopener noreferrer"' : '';
+}
+
 function navHtml(active) {
   const navItems = CONFIG.site.nav || [];
   const links = navItems.map(n => {
     const res = navResolveHref(n.href);
     const isActive = active && (n.href === active || res === active || (active === 'home' && (n.href === './' || n.href === 'index.html')));
-    return `<a class="nav-link${isActive ? ' active' : ''}" href="${escapeHtml(res)}">${escapeHtml(n.name)}</a>`;
+    return `<a class="nav-link${isActive ? ' active' : ''}" href="${escapeHtml(res)}"${navLinkAttrs(n.href)}>${escapeHtml(n.name)}</a>`;
   }).join('');
   const drawerLinks = navItems.map(n => {
     const res = navResolveHref(n.href);
     const isActive = active && (n.href === active || res === active || (active === 'home' && (n.href === './' || n.href === 'index.html')));
-    return `<a class="nav-drawer-link${isActive ? ' active' : ''}" href="${escapeHtml(res)}">${escapeHtml(n.name)}</a>`;
+    return `<a class="nav-drawer-link${isActive ? ' active' : ''}" href="${escapeHtml(res)}"${navLinkAttrs(n.href)}>${escapeHtml(n.name)}</a>`;
   }).join('');
   return `
     <nav class="nav">

--- a/scripts/release-template/config.js
+++ b/scripts/release-template/config.js
@@ -27,7 +27,6 @@ export const CONFIG = {
     locale: "zh-CN",
     nav: [
       { name: "首页", href: "./" },
-      { name: "标签", href: "tags.html" },
       { name: "归档", href: "archives.html" },
       { name: "系列", href: "series.html" },
       { name: "工具", href: "tools/" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

导航栏移除「标签」入口，新增「小助手」外链，点击在新标签页打开腾讯元器智能体体验页。

## Changes

- `assets/js/config.js`：删除 `tags.html` 导航项；新增元器助手链接
- `assets/js/site.js`：外链导航项自动加 `target="_blank"` 与 `rel="noopener noreferrer"`
- `scripts/release-template/config.js`：模板同步去掉标签导航

## Note

`tags.html` 页面仍保留，首页标签云、文章内标签链接不受影响，只是顶部导航不再展示入口。

## Test plan

- [ ] PC 导航栏无「标签」，有「小助手」
- [ ] 点击「小助手」在新标签打开元器对话页
- [ ] 移动端抽屉菜单同样生效
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7adec158-4501-474b-9753-7a7818c87603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7adec158-4501-474b-9753-7a7818c87603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

