### PR TITLE
fix: PC 装饰图加载失败处理（需补传图片文件）

### DIFF
--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -531,6 +531,13 @@ function injectAnalytics() {
   });
 }
 
+function decorImageUrl(path) {
+  const rel = String(path || '').replace(/^\/+/, '');
+  const base = String(CONFIG.site?.url || '').replace(/\/+$/, '');
+  if (base && /^https?:\/\//i.test(base)) return `${base}/${rel}`;
+  return rootPath(rel);
+}
+
 function mountPcCornerDecor() {
   const decor = CONFIG.decor || {};
   if (!decor.enabled || !decor.pcCornerImage) return;
@@ -541,10 +548,11 @@ function mountPcCornerDecor() {
   wrap.className = 'site-pc-corner-decor';
   wrap.setAttribute('aria-hidden', 'true');
   const img = document.createElement('img');
-  img.src = rootPath(String(decor.pcCornerImage).replace(/^\/+/, ''));
+  img.src = decorImageUrl(decor.pcCornerImage);
   img.alt = '';
   img.decoding = 'async';
   img.loading = 'lazy';
+  img.addEventListener('error', () => wrap.remove(), { once: true });
   wrap.appendChild(img);
   document.body.appendChild(wrap);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

修复 PC 右下角装饰图 404 时的加载逻辑；**根因是图片文件尚未入库**。

## Root cause

`config.js` 指向 `assets/uploads/2026/06/pc-corner-mascot.png`，但该文件从未提交到仓库，线上返回 404。

## Code fix

- 装饰图 URL 改用 `CONFIG.site.url` 拼绝对路径
- 图片加载失败时自动移除装饰节点

## Required: add image file

请将装饰图保存并提交到 `assets/uploads/2026/06/pc-corner-mascot.png`，或在后台上传后更新 `decor.pcCornerImage` 路径。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7adec158-4501-474b-9753-7a7818c87603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7adec158-4501-474b-9753-7a7818c87603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

