### PR TITLE
Revert PR #70: Service Worker navigation preload changes

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // 与 ?v=VERSION 的 cache-busting 协同：CACHE_NAME 用 release VERSION 区分批次
 // ============================================================================
 
-const SW_VERSION = '20260616140000';
+const SW_VERSION = '20260616150000';
 const STATIC_CACHE = `static-${SW_VERSION}`;
 const PAGE_CACHE = `pages-${SW_VERSION}`;
 const RUNTIME_CACHE = `runtime-${SW_VERSION}`;
@@ -47,10 +47,7 @@ self.addEventListener('install', event => {
 self.addEventListener('activate', event => {
   event.waitUntil(
     Promise.all([
-      // HTML 走 cache-first，navigation preload 会在命中缓存时被取消并刷控制台警告
-      self.registration.navigationPreload
-        ? self.registration.navigationPreload.disable().catch(() => {})
-        : null,
+      self.registration.navigationPreload ? self.registration.navigationPreload.enable().catch(() => {}) : null,
       caches.keys().then(keys =>
         Promise.all(keys
         .filter(k => ![STATIC_CACHE, PAGE_CACHE, RUNTIME_CACHE].includes(k))
@@ -109,23 +106,24 @@ self.addEventListener('fetch', event => {
   }
 });
 
-async function fetchAndCachePage(request) {
-  const res = await fetch(request);
-  if (res && res.status === 200) {
-    const copy = res.clone();
-    caches.open(PAGE_CACHE).then(c => c.put(request, copy)).catch(() => {});
-  }
-  return res;
-}
-
 async function handleHtml(request, event) {
   const url = new URL(request.url);
   const postArticle = isPostArticlePath(url.pathname);
 
+  const network = (event.preloadResponse || Promise.resolve(null))
+    .then(preload => preload || fetch(request))
+    .then(res => {
+      if (res && res.status === 200) {
+        const copy = res.clone();
+        caches.open(PAGE_CACHE).then(c => c.put(request, copy)).catch(() => {});
+      }
+      return res;
+    });
+
   // 文章页已预渲染完整 HTML：network-first，避免旧版「加载中…」空壳被 stale 缓存命中
   if (postArticle) {
     try {
-      const res = await fetchAndCachePage(request);
+      const res = await network;
       if (res && res.status === 200) return res;
     } catch { /* 离线回退 */ }
     const cached = await matchHtmlShell(request);
@@ -136,13 +134,13 @@ async function handleHtml(request, event) {
 
   // 导航页最影响 DCL。已有缓存时立刻返回页面壳，后台静默更新，避免慢 304 卡住首屏。
   if (cached) {
-    event.waitUntil(fetchAndCachePage(request).catch(() => {}));
+    event.waitUntil(network.catch(() => {}));
     return cached;
   }
 
   // 首次访问且没有缓存时才等网络；多等几秒避免慢网/冷启动时误落到离线页
   return Promise.race([
-    fetchAndCachePage(request).catch(() => null),
+    network.catch(() => null),
     delay(6000).then(() => null),
   ]).then(res => res || caches.match(OFFLINE_URL));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reverts #70 (Service Worker navigation preload warning fix).

Restores previous SW behavior:
- Re-enable `navigationPreload` on activate
- Use `event.preloadResponse` chain in `handleHtml` again
- Remove standalone `fetchAndCachePage` helper

Note: this may bring back the console warning:
`The service worker navigation preload request was cancelled before preloadResponse settled`.

SW cache version bumped to `20260616150000` so clients pick up the reverted worker.

## Test plan

- [ ] Hard refresh and verify SW updates
- [ ] Navigation / offline behavior still works on homepage and post pages
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7adec158-4501-474b-9753-7a7818c87603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7adec158-4501-474b-9753-7a7818c87603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

