### PR TITLE
fix(admin): 修复编辑器 Markdown 区域无法滚动

### DIFF
--- a/admin/editor.html
+++ b/admin/editor.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>编辑文章</title>
-  <link rel="stylesheet" href="../assets/css/common.css?v=20260512184000">
-  <link rel="stylesheet" href="../assets/css/admin.css?v=20260512184000">
-  <link rel="stylesheet" href="../assets/css/post.css?v=20260512184000">
+  <link rel="stylesheet" href="../assets/css/common.css?v=20260615100000">
+  <link rel="stylesheet" href="../assets/css/admin.css?v=20260615100000">
+  <link rel="stylesheet" href="../assets/css/post.css?v=20260615100000">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde@2.18.0/dist/easymde.min.css">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="../manifest.webmanifest">
@@ -44,7 +44,11 @@
   <div class="editor-body">
     <div class="editor-pane" style="position:relative">
       <input class="editor-title" id="title" placeholder="输入文章标题">
-      <div class="editor-meta">
+      <div class="editor-meta" id="editorMeta">
+        <div class="editor-meta-toolbar">
+          <span>文章信息</span>
+          <button type="button" class="editor-meta-collapse" id="metaCollapseBtn" aria-expanded="true" aria-controls="editorMeta">收起</button>
+        </div>
         <label>作者 <input id="author" placeholder="作者"></label>
         <div class="editor-tag-field">
           <span class="editor-meta-label">标签</span>
@@ -82,6 +86,6 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/easymde@2.18.0/dist/easymde.min.js"></script>
-  <script type="module" src="../assets/js/editor.js?v=20260512184000"></script>
+  <script type="module" src="../assets/js/editor.js?v=20260615100000"></script>
 </body>
 </html>

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -584,9 +584,11 @@
 /* ---------- 编辑器 ---------- */
 .editor-page {
   height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
   background: var(--bg);
+  overflow: hidden;
 }
 
 .editor-bar {
@@ -678,20 +680,24 @@
 
 .editor-body {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  flex: 1;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  flex: 1 1 0;
+  min-height: 0;
   overflow: hidden;
 }
 
 .editor-pane {
   display: flex;
   flex-direction: column;
+  min-height: 0;
+  min-width: 0;
   overflow: hidden;
   border-right: 1px solid var(--border);
 }
 .editor-pane:last-child { border-right: none; }
 
 .editor-title {
+  flex-shrink: 0;
   padding: 24px 32px 8px;
   font-size: 28px;
   font-weight: 700;
@@ -704,6 +710,7 @@
 .editor-title::placeholder { color: var(--text-tertiary); }
 
 .editor-meta {
+  flex-shrink: 0;
   padding: 0 32px 12px;
   display: flex;
   flex-wrap: wrap;
@@ -711,7 +718,41 @@
   font-size: 12px;
   color: var(--text-secondary);
   border-bottom: 1px solid var(--border);
+  max-height: min(40vh, 340px);
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+  transition: max-height 0.2s ease, padding 0.2s ease;
 }
+.editor-meta.is-collapsed {
+  max-height: 36px;
+  overflow: hidden;
+  padding-bottom: 8px;
+}
+.editor-meta-toolbar {
+  flex: 1 1 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: -2px;
+}
+.editor-meta-toolbar span {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.editor-meta-collapse {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--primary);
+  font-size: 12px;
+  padding: 2px 4px;
+  cursor: pointer;
+}
+.editor-meta-collapse:hover { text-decoration: underline; }
 .editor-meta input {
   background: var(--bg-soft);
   padding: 5px 10px;
@@ -847,7 +888,8 @@
 }
 
 .editor-textarea {
-  flex: 1;
+  flex: 1 1 0;
+  min-height: 0;
   padding: 18px 32px 32px;
   font-family: var(--font-mono);
   font-size: 14px;
@@ -857,11 +899,18 @@
   outline: none;
   background: var(--bg);
   color: var(--text-main);
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .editor-preview {
+  flex: 1 1 0;
+  min-height: 0;
   padding: 24px 32px;
+  overflow-x: hidden;
   overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
   background: var(--bg-soft);
 }
 .editor-preview .article-title { font-size: 24px; margin-bottom: 16px; }
@@ -884,11 +933,10 @@
 }
 
 /* EasyMDE 集成时的样式 —— 必须形成 flex 高度链路：
-   .editor-pane(overflow:hidden) → .EasyMDEContainer(flex:1, min-height:0)
-   → .CodeMirror(flex:1, min-height:0) → .CodeMirror-scroll(overflow:auto)
-   否则 CodeMirror 会被内容撑大并被外层裁掉，滚动条消失 */
+   .editor-pane(min-height:0) → .EasyMDEContainer(flex:1) → .CodeMirror(固定高度由 JS 写入)
+   → .CodeMirror-scroll(overflow:auto)。父级用 height:auto 会导致内部无法滚动。 */
 .EasyMDEContainer {
-  flex: 1;
+  flex: 1 1 0;
   min-height: 0;
   display: flex;
   flex-direction: column;
@@ -896,22 +944,18 @@
   overflow: hidden;
 }
 .EasyMDEContainer .CodeMirror {
-  flex: 1;
-  min-height: 0;
-  height: auto !important;       /* 抵消 EasyMDE 写入的 inline height */
+  flex: 1 1 0;
+  min-height: 120px;
   background: transparent;
   color: var(--text-main);
   border: none;
   padding: 12px 0;
 }
 .EasyMDEContainer .CodeMirror-scroll {
-  height: 100% !important;
-  max-height: none !important;
   min-height: 0;
   overflow: auto !important;
   -webkit-overflow-scrolling: touch;
 }
-.EasyMDEContainer .CodeMirror-sizer { min-height: 0 !important; }
 .EasyMDEContainer .editor-toolbar {
   flex-shrink: 0;
   border: 1px solid var(--border);

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -121,6 +121,7 @@ async function loadPost(slug) {
     setStatus('已加载', 'saved');
     $('#btnDelete').style.display = '';
     updatePreview();
+    refreshEditorLayout();
   } catch (e) {
     console.error(e);
     if (e.status === 401) { logout(window.location.href); return; }
@@ -722,6 +723,7 @@ async function setupVditor(initialMd) {
         const v = state.vditorPendingValue || initialMd || '';
         if (v) state.vditor.setValue(v);
         state.vditorPendingValue = '';
+        refreshEditorLayout();
         resolve();
       },
     });
@@ -764,6 +766,7 @@ async function switchEditorMode(target) {
 
     state.editorMode = 'rich';
     document.querySelector('.editor-pane').classList.add('is-rich');
+    refreshEditorLayout();
   } else {
     // 富文本 → Markdown：取 Vditor markdown 灌回 EasyMDE
     if (state.vditor && state.vditorReady) {
@@ -776,6 +779,7 @@ async function switchEditorMode(target) {
     document.querySelector('.editor-pane').classList.remove('is-rich');
     setStatus('已切换到 Markdown', 'saved');
     if (state.mde && state.mde.codemirror) state.mde.codemirror.refresh();
+    refreshEditorLayout();
   }
 
   buttons.forEach(b => {
@@ -805,6 +809,80 @@ function bindEditorModeSwitch() {
   obs.observe(document.documentElement, { attributes: true, attributeFilter: ['data-mode'] });
 }
 
+function debounce(fn, ms) {
+  let timer = null;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), ms);
+  };
+}
+
+/** 根据左侧编辑区剩余高度，重算 CodeMirror / Vditor 尺寸，修复无法内部滚动的问题 */
+function refreshEditorLayout() {
+  if (state.editorMode === 'markdown' && state.mde && state.mde.codemirror) {
+    const container = document.querySelector('.EasyMDEContainer');
+    const cm = state.mde.codemirror;
+    if (container && cm) {
+      const toolbar = container.querySelector('.editor-toolbar');
+      const styles = getComputedStyle(container);
+      const padY = parseFloat(styles.paddingTop) + parseFloat(styles.paddingBottom);
+      const toolH = toolbar ? toolbar.offsetHeight + 8 : 0;
+      const available = container.clientHeight - toolH - padY;
+      if (available > 80) {
+        cm.setSize(null, available);
+      }
+      cm.refresh();
+    }
+  }
+  if (state.editorMode === 'rich' && state.vditor && state.vditorReady) {
+    try { state.vditor.resize(); } catch (_) { /* ignore */ }
+  }
+}
+
+let editorLayoutObserver = null;
+function bindEditorLayoutRefresh() {
+  const pane = document.querySelector('.editor-pane');
+  const run = () => requestAnimationFrame(refreshEditorLayout);
+
+  window.addEventListener('resize', debounce(run, 120));
+
+  if (typeof ResizeObserver !== 'undefined') {
+    editorLayoutObserver = new ResizeObserver(debounce(run, 80));
+    if (pane) editorLayoutObserver.observe(pane);
+    const meta = $('#editorMeta');
+    if (meta) editorLayoutObserver.observe(meta);
+    const body = document.querySelector('.editor-body');
+    if (body) editorLayoutObserver.observe(body);
+    const mdeContainer = document.querySelector('.EasyMDEContainer');
+    if (mdeContainer) editorLayoutObserver.observe(mdeContainer);
+  }
+
+  run();
+  setTimeout(run, 200);
+  setTimeout(run, 800);
+}
+
+function bindMetaCollapse() {
+  const meta = $('#editorMeta');
+  const btn = $('#metaCollapseBtn');
+  if (!meta || !btn) return;
+
+  const key = 'editor_meta_collapsed';
+  const collapsed = localStorage.getItem(key) === '1';
+  meta.classList.toggle('is-collapsed', collapsed);
+  btn.textContent = collapsed ? '展开' : '收起';
+  btn.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+
+  btn.addEventListener('click', () => {
+    const next = !meta.classList.contains('is-collapsed');
+    meta.classList.toggle('is-collapsed', next);
+    btn.textContent = next ? '展开' : '收起';
+    btn.setAttribute('aria-expanded', next ? 'false' : 'true');
+    localStorage.setItem(key, next ? '1' : '0');
+    refreshEditorLayout();
+  });
+}
+
 function setupEasyMDE() {
   if (typeof EasyMDE === 'undefined') {
     // 没加载到 EasyMDE 就回退到 textarea
@@ -815,7 +893,6 @@ function setupEasyMDE() {
     autoDownloadFontAwesome: true,
     spellChecker: false,
     status: false,
-    minHeight: '300px',
     placeholder: '开始用 Markdown 写作。支持拖拽 / 粘贴上传图片',
     toolbar: [
       'bold', 'italic', 'heading', '|',
@@ -843,6 +920,7 @@ function setupEasyMDE() {
     // 富文本模式下 EasyMDE 是被动同步 buffer，不要回头触发预览（以富文本 input 为准）
     if (state.editorMode === 'markdown') updatePreview();
   });
+  refreshEditorLayout();
 }
 
 (async function init() {
@@ -864,6 +942,8 @@ function setupEasyMDE() {
   $('#author').value = (getUser() && getUser().name) || CONFIG.site.author || '';
 
   setupEasyMDE();
+  bindEditorLayoutRefresh();
+  bindMetaCollapse();
   bindEditorModeSwitch();
   setupDragAndPaste();
   bindTagPicker();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

后台写文章时，左侧 Markdown 编辑区无法向下滚动查看长文内容（CodeMirror 被外层裁切，内部滚动条失效）。

## 原因

1. `editor-body` / `editor-pane` 缺少 `min-height: 0`，flex 子项无法正确收缩
2. `.CodeMirror` 被设为 `height: auto`，导致 `.CodeMirror-scroll` 的 `height: 100%` 失效
3. `.CodeMirror-sizer { min-height: 0 }` 干扰了 CodeMirror 正常计算可滚动高度
4. EasyMDE 的 `minHeight: 300px` 与 flex 布局冲突

## 修复

- 补全整条 flex 高度链（`100dvh` → `editor-body` → `editor-pane` → `EasyMDEContainer`）
- 新增 `refreshEditorLayout()`：按容器剩余高度调用 `cm.setSize()`，并用 `ResizeObserver` 在窗口/元信息区变化时自动刷新
- 文章信息区（作者/标签/封面/slug）支持**收起/展开**，过长时独立滚动，避免挤压编辑区
- 右侧预览区同步使用 flex 高度链，保证两侧均可独立滚动

## 变更文件

- `admin/editor.html` — 文章信息收起按钮 + 缓存版本号
- `assets/css/admin.css` — 布局与 CodeMirror 样式修复
- `assets/js/editor.js` — 尺寸刷新与交互逻辑
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53890161-a286-43a2-9d7b-d41551c87404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53890161-a286-43a2-9d7b-d41551c87404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

