### PR TITLE
feat(admin): 文档工作室式编辑界面 + 修复 Markdown 滚动

### DIFF
--- a/admin/editor.html
+++ b/admin/editor.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>编辑文章</title>
-  <link rel="stylesheet" href="../assets/css/common.css?v=20260615100000">
-  <link rel="stylesheet" href="../assets/css/admin.css?v=20260615100000">
-  <link rel="stylesheet" href="../assets/css/post.css?v=20260615100000">
+  <link rel="stylesheet" href="../assets/css/common.css?v=20260615120000">
+  <link rel="stylesheet" href="../assets/css/admin.css?v=20260615120000">
+  <link rel="stylesheet" href="../assets/css/post.css?v=20260615120000">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde@2.18.0/dist/easymde.min.css">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="../manifest.webmanifest">
@@ -15,77 +15,133 @@
   <link rel="apple-touch-icon" href="../assets/icon.svg">
   <meta name="apple-mobile-web-app-capable" content="yes">
 </head>
-<body class="editor-page">
-  <div class="editor-bar">
-    <a class="back" href="./">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
-      返回
-    </a>
-    <div class="editor-mode-switch" role="tablist" aria-label="编辑模式">
-      <button type="button" class="editor-mode-btn is-active" data-mode="markdown" role="tab" aria-selected="true" title="Markdown 源码模式（适合熟悉 Markdown 的写作者）">Markdown</button>
-      <button type="button" class="editor-mode-btn" data-mode="rich" role="tab" aria-selected="false" title="所见即所得富文本模式（不需要懂 Markdown 也能写）">富文本</button>
+<body class="editor-page editor-studio">
+  <header class="studio-header">
+    <div class="studio-header-left">
+      <a class="studio-back" href="./">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+        后台
+      </a>
+      <a class="btn btn-primary studio-btn-new" href="./editor.html">新建</a>
+      <button type="button" class="studio-icon-btn studio-only-mobile" id="btnToggleNav" title="文章列表" aria-label="文章列表">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 6h16M4 12h16M4 18h10"/></svg>
+      </button>
     </div>
-    <span class="editor-status" id="status">未登录</span>
-    <div class="editor-toggle-row">
-      <label><input type="checkbox" id="draftToggle"> 草稿</label>
-      <label><input type="checkbox" id="pinnedToggle"> 置顶</label>
-      <label title="勾选后将出现在首页轮播图（需有封面）"><input type="checkbox" id="carouselToggle"> 轮播</label>
+    <div class="studio-header-center">
+      <span class="editor-status" id="status">未登录</span>
     </div>
-    <button id="themeToggle" class="icon-btn" title="切换主题">
-      <svg class="icon-light" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
-      <svg class="icon-dark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
-      <svg class="icon-auto" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/></svg>
-    </button>
-    <button class="btn btn-secondary" id="btnPreview">预览</button>
-    <button class="btn btn-secondary" id="btnDelete" style="display:none">删除</button>
-    <button class="btn btn-primary" id="btnPublish">发布</button>
-  </div>
+    <div class="studio-header-right">
+      <div class="editor-mode-switch" role="tablist" aria-label="编辑模式">
+        <button type="button" class="editor-mode-btn is-active" data-mode="markdown" role="tab" aria-selected="true" title="Markdown 源码">Markdown</button>
+        <button type="button" class="editor-mode-btn" data-mode="rich" role="tab" aria-selected="false" title="富文本模式">富文本</button>
+      </div>
+      <div class="editor-toggle-row">
+        <label><input type="checkbox" id="draftToggle"> 草稿</label>
+        <label><input type="checkbox" id="pinnedToggle"> 置顶</label>
+        <label title="需有封面"><input type="checkbox" id="carouselToggle"> 轮播</label>
+      </div>
+      <button id="themeToggle" class="icon-btn" title="切换主题">
+        <svg class="icon-light" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+        <svg class="icon-dark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        <svg class="icon-auto" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/></svg>
+      </button>
+      <button class="btn btn-secondary studio-only-mobile" id="btnPreview" type="button">预览</button>
+      <button class="btn btn-secondary studio-only-mobile" id="btnToggleOutline" type="button" title="目录">目录</button>
+      <button class="btn btn-secondary" id="btnDelete" style="display:none" type="button">删除</button>
+      <button class="btn btn-primary" id="btnPublish" type="button">发布</button>
+    </div>
+  </header>
 
-  <div class="editor-body">
-    <div class="editor-pane" style="position:relative">
-      <input class="editor-title" id="title" placeholder="输入文章标题">
-      <div class="editor-meta" id="editorMeta">
+  <div class="studio-shell" id="studioShell">
+    <aside class="studio-nav" id="studioNav">
+      <div class="studio-side-head">
+        <strong>文章</strong>
+        <button type="button" class="studio-side-toggle" id="navCollapseBtn" title="收起侧栏" aria-label="收起侧栏">‹</button>
+      </div>
+      <div class="studio-nav-search">
+        <input id="docSearch" type="search" placeholder="搜索标题或 slug…" autocomplete="off">
+      </div>
+      <nav class="studio-doc-list" id="docList" aria-label="文章列表"></nav>
+
+      <div class="studio-nav-meta" id="editorMeta">
         <div class="editor-meta-toolbar">
           <span>文章信息</span>
           <button type="button" class="editor-meta-collapse" id="metaCollapseBtn" aria-expanded="true" aria-controls="editorMeta">收起</button>
         </div>
-        <label>作者 <input id="author" placeholder="作者"></label>
-        <div class="editor-tag-field">
-          <span class="editor-meta-label">标签</span>
-          <input id="tags" type="hidden">
-          <div class="editor-selected-tags" id="selectedTags" aria-live="polite"></div>
-          <div class="editor-tag-input-row">
-            <input id="tagInput" placeholder="输入新标签后回车">
-            <button class="btn btn-secondary" id="addTagBtn" type="button">添加</button>
+        <div class="studio-meta-body">
+          <label class="studio-field">作者 <input id="author" placeholder="作者"></label>
+          <label class="studio-field">封面 <input id="cover" placeholder="封面图 URL"></label>
+          <label class="studio-field">slug <input id="slug" placeholder="自动生成"></label>
+          <div class="studio-field studio-summary-field">
+            <span class="editor-meta-label">摘要</span>
+            <p class="studio-summary-text" id="summaryPreview">发布时自动从正文提取，也可点下方「生成摘要」</p>
           </div>
-          <div class="editor-tag-suggestions" id="tagSuggestions"></div>
-        </div>
-        <label>封面 <input id="cover" placeholder="封面图 URL，可选"></label>
-        <label>slug <input id="slug" placeholder="自动生成"></label>
-        <div class="editor-counter-field" id="counterField" hidden>
-          <span class="editor-meta-label">独立计数器（saobby）</span>
-          <div class="editor-counter-row">
-            <button type="button" class="btn btn-secondary" id="counterCreateBtn" title="去 saobby.com 为这篇文章创建一个独立计数器">为本文创建计数器…</button>
-            <button type="button" class="btn" id="counterPasteBtn" title="把 saobby 给的图片 URL + 控制面板 URL 粘进来">粘贴 URL…</button>
-            <button type="button" class="btn" id="counterClearBtn" hidden title="清除计数器配置">清除</button>
+          <div class="editor-tag-field">
+            <span class="editor-meta-label">标签</span>
+            <input id="tags" type="hidden">
+            <div class="editor-selected-tags" id="selectedTags" aria-live="polite"></div>
+            <div class="editor-tag-input-row">
+              <input id="tagInput" placeholder="输入标签后回车">
+              <button class="btn btn-secondary" id="addTagBtn" type="button">添加</button>
+            </div>
+            <div class="editor-tag-suggestions" id="tagSuggestions"></div>
           </div>
-          <div class="editor-counter-summary" id="counterSummary"></div>
+          <div class="editor-counter-field" id="counterField" hidden>
+            <span class="editor-meta-label">独立计数器（saobby）</span>
+            <div class="editor-counter-row">
+              <button type="button" class="btn btn-secondary" id="counterCreateBtn">创建计数器…</button>
+              <button type="button" class="btn" id="counterPasteBtn">粘贴 URL…</button>
+              <button type="button" class="btn" id="counterClearBtn" hidden>清除</button>
+            </div>
+            <div class="editor-counter-summary" id="counterSummary"></div>
+          </div>
         </div>
       </div>
-      <textarea class="editor-textarea" id="content" placeholder="开始用 Markdown 写作。支持拖拽 / 粘贴上传图片"></textarea>
-      <!-- 富文本（WYSIWYG）模式宿主：默认隐藏，首次切到「富文本」时才懒加载 Vditor -->
-      <div id="vditorHost" class="editor-vditor-host" hidden></div>
-      <div id="dropHint" class="editor-drop-hint" hidden>松开以上传图片</div>
-    </div>
-    <div class="editor-pane">
-      <div class="editor-preview">
-        <h1 class="article-title" id="previewTitle">预览</h1>
-        <div class="article-body" id="preview"></div>
+    </aside>
+
+    <main class="studio-main">
+      <div class="studio-titlebar">
+        <input class="studio-title" id="title" placeholder="无标题文章">
       </div>
-    </div>
+
+      <div class="studio-workspace" id="studioWorkspace">
+        <section class="studio-panel studio-panel-source">
+          <header class="studio-panel-head"><span>编辑</span></header>
+          <div class="studio-panel-body studio-source-body">
+            <textarea class="editor-textarea" id="content" placeholder="开始用 Markdown 写作。支持拖拽 / 粘贴上传图片"></textarea>
+            <div id="vditorHost" class="editor-vditor-host" hidden></div>
+            <div id="dropHint" class="editor-drop-hint" hidden>松开以上传图片</div>
+          </div>
+          <footer class="studio-panel-foot">
+            <button type="button" class="studio-foot-btn" id="footAddTag">+ 添加标签</button>
+            <button type="button" class="studio-foot-btn studio-foot-btn-ai" id="btnGenSummary">生成摘要</button>
+          </footer>
+        </section>
+
+        <div class="studio-splitter" id="studioSplitter" role="separator" aria-orientation="vertical" aria-label="调整编辑与预览宽度"></div>
+
+        <section class="studio-panel studio-panel-preview">
+          <header class="studio-panel-head"><span>预览</span></header>
+          <div class="studio-panel-body editor-preview" id="previewPane">
+            <h1 class="article-title" id="previewTitle">预览</h1>
+            <div class="article-body" id="preview"></div>
+          </div>
+        </section>
+      </div>
+    </main>
+
+    <aside class="studio-outline" id="studioOutline">
+      <div class="studio-side-head">
+        <strong>目录</strong>
+        <button type="button" class="studio-side-toggle" id="outlineCollapseBtn" title="收起目录" aria-label="收起目录">›</button>
+      </div>
+      <nav class="studio-toc" id="docToc" aria-label="文档目录">
+        <p class="studio-toc-empty">正文标题将自动生成目录</p>
+      </nav>
+    </aside>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/easymde@2.18.0/dist/easymde.min.js"></script>
-  <script type="module" src="../assets/js/editor.js?v=20260615100000"></script>
+  <script type="module" src="../assets/js/editor.js?v=20260615120000"></script>
 </body>
 </html>

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1077,6 +1077,505 @@ html[data-mode="dark"] .editor-vditor-host .vditor-toolbar__item .vditor-tooltip
   .editor-tag-input-row .btn { width: 100%; }
 }
 
+/* ================================================================== */
+/* 文档工作室布局（editor-studio）— 左导航 / 中编辑预览 / 右目录        */
+/* ================================================================== */
+.editor-studio {
+  --studio-nav-w: 260px;
+  --studio-outline-w: 220px;
+  --studio-splitter: 5px;
+  background: var(--bg-soft);
+}
+
+.studio-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 52px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+.studio-header-left,
+.studio-header-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.studio-header-center {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  justify-content: center;
+}
+.studio-header .editor-status {
+  margin-right: 0;
+  max-width: none;
+  text-align: center;
+}
+.studio-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+.studio-back:hover { color: var(--primary); }
+.studio-btn-new {
+  padding: 6px 14px;
+  font-size: 13px;
+  border-radius: 6px;
+}
+.studio-icon-btn {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--bg-soft);
+  color: var(--text-secondary);
+  width: 34px;
+  height: 34px;
+  border-radius: 6px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.studio-only-mobile { display: none; }
+
+.studio-shell {
+  display: flex;
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: hidden;
+}
+.studio-shell.is-nav-collapsed { --studio-nav-w: 0px; }
+.studio-shell.is-outline-collapsed { --studio-outline-w: 0px; }
+
+.studio-nav,
+.studio-outline {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--bg);
+  border-right: 1px solid var(--border);
+  overflow: hidden;
+  transition: width 0.2s ease, opacity 0.2s ease;
+}
+.studio-nav {
+  width: var(--studio-nav-w);
+  border-right: 1px solid var(--border);
+}
+.studio-outline {
+  width: var(--studio-outline-w);
+  border-right: none;
+  border-left: 1px solid var(--border);
+}
+.studio-shell.is-nav-collapsed .studio-nav {
+  width: 0;
+  border-right-width: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+.studio-shell.is-outline-collapsed .studio-outline {
+  width: 0;
+  border-left-width: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.studio-side-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px 14px 10px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.studio-side-head strong {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-main);
+}
+.studio-side-toggle {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--text-tertiary);
+  font-size: 18px;
+  line-height: 1;
+  padding: 2px 6px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.studio-side-toggle:hover {
+  color: var(--text-main);
+  background: var(--bg-soft);
+}
+
+.studio-nav-search {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.studio-nav-search input {
+  width: 100%;
+  padding: 7px 10px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-soft);
+  color: var(--text-main);
+  outline: none;
+}
+.studio-nav-search input:focus { border-color: var(--primary); }
+
+.studio-doc-list {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 6px 0;
+}
+.studio-doc-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  text-decoration: none;
+  border-left: 3px solid transparent;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.studio-doc-item:hover {
+  background: var(--bg-soft);
+  color: var(--text-main);
+}
+.studio-doc-item.is-active {
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
+  color: var(--primary);
+  border-left-color: var(--primary);
+  font-weight: 600;
+}
+.studio-doc-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.studio-doc-badge {
+  flex-shrink: 0;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--bg-elev);
+  color: var(--text-tertiary);
+  border: 1px solid var(--border);
+}
+.studio-nav-empty {
+  padding: 16px 14px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin: 0;
+}
+
+.studio-nav-meta {
+  flex-shrink: 0;
+  max-height: 42vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--border);
+  background: var(--bg-soft);
+}
+.studio-nav-meta.is-collapsed { max-height: 40px; }
+.studio-nav-meta .editor-meta-toolbar {
+  padding: 8px 12px 0;
+  margin-bottom: 0;
+}
+.studio-meta-body {
+  padding: 8px 12px 12px;
+  overflow-y: auto;
+  display: grid;
+  gap: 10px;
+}
+.studio-nav-meta.is-collapsed .studio-meta-body { display: none; }
+.studio-field {
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.studio-field input {
+  width: 100%;
+  padding: 6px 10px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text-main);
+}
+.studio-field input:focus {
+  outline: none;
+  border-color: var(--primary);
+}
+.studio-summary-text {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-tertiary);
+  word-break: break-word;
+}
+
+.studio-main {
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg);
+}
+.studio-titlebar {
+  flex-shrink: 0;
+  padding: 14px 20px 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+}
+.studio-title {
+  width: 100%;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-main);
+  line-height: 1.35;
+}
+.studio-title::placeholder { color: var(--text-tertiary); }
+
+.studio-workspace {
+  flex: 1 1 0;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--studio-splitter) minmax(0, 1fr);
+  overflow: hidden;
+}
+.studio-panel {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg);
+}
+.studio-panel-head {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 14px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-soft);
+}
+.studio-panel-body {
+  flex: 1 1 0;
+  min-height: 0;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.studio-source-body {
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.studio-panel-foot {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-soft);
+}
+.studio-foot-btn {
+  appearance: none;
+  border: 1px dashed var(--border);
+  background: var(--bg);
+  color: var(--text-secondary);
+  font-size: 12px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.studio-foot-btn:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+.studio-foot-btn-ai {
+  border-style: solid;
+  background: color-mix(in srgb, #67c23a 12%, var(--bg));
+  border-color: color-mix(in srgb, #67c23a 35%, var(--border));
+  color: #3d8b2f;
+}
+html[data-mode="dark"] .studio-foot-btn-ai {
+  color: #8fd46a;
+}
+
+.studio-splitter {
+  cursor: col-resize;
+  background: var(--border);
+  position: relative;
+  z-index: 2;
+  transition: background 0.15s;
+}
+.studio-splitter:hover,
+.studio-splitter.is-dragging {
+  background: var(--primary);
+}
+.studio-splitter::after {
+  content: '';
+  position: absolute;
+  inset: 0 -3px;
+}
+
+.studio-toc {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 10px 0 16px;
+}
+.studio-toc-empty {
+  margin: 0;
+  padding: 8px 14px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  line-height: 1.5;
+}
+.studio-toc-link {
+  display: block;
+  padding: 5px 14px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  transition: color 0.12s, background 0.12s, border-color 0.12s;
+}
+.studio-toc-link:hover {
+  color: var(--primary);
+  background: var(--bg-soft);
+}
+.studio-toc-link.is-active {
+  color: var(--primary);
+  border-left-color: var(--primary);
+  background: color-mix(in srgb, var(--primary) 8%, transparent);
+  font-weight: 600;
+}
+.studio-toc-link.is-h3 { padding-left: 26px; font-size: 12px; }
+.studio-toc-link.is-h4 { padding-left: 38px; font-size: 11.5px; }
+
+/* studio 内 EasyMDE / 预览适配 */
+.editor-studio .EasyMDEContainer {
+  padding: 10px 16px 12px;
+}
+.editor-studio .editor-textarea {
+  padding: 14px 16px;
+}
+.editor-studio .editor-preview {
+  padding: 16px 20px 28px;
+  background: var(--bg);
+}
+.editor-studio .editor-vditor-host {
+  padding: 10px 16px 12px;
+}
+.editor-studio .studio-panel-source.is-rich .EasyMDEContainer,
+.editor-studio .studio-panel-source.is-rich .editor-textarea {
+  display: none !important;
+}
+.editor-studio .EasyMDEContainer .editor-toolbar {
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+.editor-studio .EasyMDEContainer .CodeMirror {
+  font-size: 13.5px;
+  line-height: 1.7;
+  padding: 8px 0;
+}
+.editor-studio .editor-preview .article-title {
+  font-size: 22px;
+  margin-bottom: 14px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+}
+.editor-studio .editor-preview .article-body {
+  font-size: 14.5px;
+}
+
+@media (max-width: 1100px) {
+  .editor-studio { --studio-outline-w: 190px; --studio-nav-w: 220px; }
+}
+
+@media (max-width: 960px) {
+  .studio-only-mobile { display: inline-flex; }
+  .studio-icon-btn { display: inline-flex; }
+  .editor-studio { --studio-nav-w: 0px; --studio-outline-w: 0px; }
+  .studio-nav,
+  .studio-outline {
+    position: fixed;
+    top: 52px;
+    bottom: 0;
+    z-index: 40;
+    width: min(86vw, 300px) !important;
+    opacity: 1 !important;
+    pointer-events: auto !important;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+  }
+  .studio-nav { left: 0; transform: translateX(-105%); transition: transform 0.22s ease; }
+  .studio-outline { right: 0; left: auto; transform: translateX(105%); border-left: 1px solid var(--border); }
+  .studio-shell.is-mobile-nav-open .studio-nav { transform: translateX(0); }
+  .studio-shell.is-mobile-outline-open .studio-outline { transform: translateX(0); }
+  .studio-shell.is-nav-collapsed .studio-nav,
+  .studio-shell.is-outline-collapsed .studio-outline {
+    transform: translateX(-105%);
+  }
+  .studio-shell.is-outline-collapsed.is-mobile-outline-open .studio-outline {
+    transform: translateX(0);
+  }
+  .studio-workspace {
+    grid-template-columns: minmax(0, 1fr) 0 minmax(0, 1fr);
+  }
+  .studio-splitter { display: none; }
+  .studio-shell.is-preview-only .studio-panel-source { display: none; }
+  .studio-shell.is-preview-only .studio-panel-preview { grid-column: 1 / -1; }
+  .studio-shell.is-edit-only .studio-panel-preview { display: none; }
+  .studio-shell.is-edit-only .studio-panel-source { grid-column: 1 / -1; }
+  .studio-header-center { order: 10; flex: 1 0 100%; }
+}
+
+@media (max-width: 640px) {
+  .studio-header { padding: 8px 10px; gap: 8px; }
+  .studio-header-right .editor-toggle-row { display: none; }
+  .studio-titlebar { padding: 12px 14px 8px; }
+  .studio-title { font-size: 19px; }
+}
+
 /* ---------- 模态框 ---------- */
 .modal-mask {
   position: fixed;

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -57,6 +57,9 @@ const state = {
   selectedTags: [],
   availableTags: [],
   counter: { img: '', dashboard: '' }, // 文章独立 saobby 计数器
+  docList: [],
+  docSearch: '',
+  syncScrollLock: false,
 };
 
 function getContent() {
@@ -118,6 +121,7 @@ async function loadPost(slug) {
     setEditorCounter(data.counter || { img: '', dashboard: '' });
     setContent(content);
     document.title = `编辑：${data.title || slug}`;
+    renderSummaryPreview();
     setStatus('已加载', 'saved');
     $('#btnDelete').style.display = '';
     updatePreview();
@@ -138,7 +142,87 @@ async function updatePreview() {
     const t = $('#title').value || '预览';
     $('#previewTitle').textContent = t;
     $('#preview').innerHTML = await renderMarkdown(getContent());
+    buildToc();
+    renderSummaryPreview();
+    renderDocList(state.docSearch);
   }, 200);
+}
+
+function renderSummaryPreview() {
+  const el = $('#summaryPreview');
+  if (!el) return;
+  const content = getContent();
+  const summary = state.data.summary || extractSummary(content, 120);
+  el.textContent = summary || '发布时自动从正文提取，也可点「生成摘要」';
+}
+
+function buildToc() {
+  const preview = $('#preview');
+  const toc = $('#docToc');
+  if (!preview || !toc) return;
+
+  const headings = [...preview.querySelectorAll('h2, h3, h4')];
+  if (!headings.length) {
+    toc.innerHTML = '<p class="studio-toc-empty">正文标题将自动生成目录</p>';
+    return;
+  }
+
+  headings.forEach((h, i) => {
+    if (!h.id) h.id = `studio-h-${i}`;
+  });
+
+  toc.innerHTML = headings.map(h => {
+    const level = h.tagName.toLowerCase();
+    return `<a class="studio-toc-link is-${level}" href="#${h.id}" data-target="${h.id}">${escapeHtml(h.textContent.trim())}</a>`;
+  }).join('');
+
+  toc.querySelectorAll('.studio-toc-link').forEach(link => {
+    link.addEventListener('click', e => {
+      e.preventDefault();
+      const target = preview.querySelector(`#${link.dataset.target}`);
+      const pane = $('#previewPane');
+      if (target && pane) {
+        const top = target.offsetTop - pane.offsetTop - 12;
+        pane.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+      }
+      toc.querySelectorAll('.studio-toc-link').forEach(a => a.classList.remove('is-active'));
+      link.classList.add('is-active');
+    });
+  });
+}
+
+async function loadDocList() {
+  try {
+    const idx = await readIndex();
+    state.docList = ((idx && idx.data && idx.data.posts) || [])
+      .filter(p => !p.page)
+      .sort((a, b) => new Date(b.updated || b.date) - new Date(a.updated || a.date));
+    renderDocList(state.docSearch);
+  } catch (e) {
+    console.warn('文章列表加载失败', e);
+  }
+}
+
+function renderDocList(filter = '') {
+  const list = $('#docList');
+  if (!list) return;
+  const q = String(filter || '').trim().toLowerCase();
+  const currentSlug = state.loadedSlug || ($('#slug') && $('#slug').value) || '';
+  const items = state.docList.filter(p => {
+    if (!q) return true;
+    return (p.title || '').toLowerCase().includes(q) || (p.slug || '').toLowerCase().includes(q);
+  });
+
+  list.innerHTML = items.length
+    ? items.map(p => `
+        <a class="studio-doc-item${p.slug === currentSlug ? ' is-active' : ''}${p.draft ? ' is-draft' : ''}"
+           href="./editor.html?slug=${encodeURIComponent(p.slug)}"
+           title="${escapeHtml(p.title || p.slug)}">
+          <span class="studio-doc-title">${escapeHtml(p.title || p.slug)}</span>
+          ${p.draft ? '<span class="studio-doc-badge">草稿</span>' : ''}
+        </a>
+      `).join('')
+    : '<p class="studio-nav-empty">没有匹配的文章</p>';
 }
 
 function toCommaList(s) {
@@ -458,6 +542,8 @@ async function publish() {
     state.data = data;
     setStatus(draft ? '已保存为草稿' : '已发布', 'saved');
     showToast(draft ? '草稿已保存' : '发布成功，几十秒后线上生效');
+    loadDocList();
+    renderSummaryPreview();
 
     const newUrl = new URL(window.location.href);
     newUrl.searchParams.set('slug', slug);
@@ -592,8 +678,9 @@ function insertAtCursor(text) {
 }
 
 function setupDragAndPaste() {
-  const pane = document.querySelector('.editor-pane');
+  const pane = document.querySelector('.studio-source-body') || document.querySelector('.editor-pane');
   const hint = $('#dropHint');
+  if (!pane) return;
 
   ['dragenter', 'dragover'].forEach(ev =>
     pane.addEventListener(ev, e => {
@@ -765,7 +852,8 @@ async function switchEditorMode(target) {
     }
 
     state.editorMode = 'rich';
-    document.querySelector('.editor-pane').classList.add('is-rich');
+    const sourcePanel = document.querySelector('.studio-panel-source') || document.querySelector('.editor-pane');
+    if (sourcePanel) sourcePanel.classList.add('is-rich');
     refreshEditorLayout();
   } else {
     // 富文本 → Markdown：取 Vditor markdown 灌回 EasyMDE
@@ -776,7 +864,8 @@ async function switchEditorMode(target) {
     }
     $('#vditorHost').hidden = true;
     state.editorMode = 'markdown';
-    document.querySelector('.editor-pane').classList.remove('is-rich');
+    const sourcePanel = document.querySelector('.studio-panel-source') || document.querySelector('.editor-pane');
+    if (sourcePanel) sourcePanel.classList.remove('is-rich');
     setStatus('已切换到 Markdown', 'saved');
     if (state.mde && state.mde.codemirror) state.mde.codemirror.refresh();
     refreshEditorLayout();
@@ -841,7 +930,9 @@ function refreshEditorLayout() {
 
 let editorLayoutObserver = null;
 function bindEditorLayoutRefresh() {
-  const pane = document.querySelector('.editor-pane');
+  const pane = document.querySelector('.studio-source-body')
+    || document.querySelector('.studio-panel-source')
+    || document.querySelector('.editor-pane');
   const run = () => requestAnimationFrame(refreshEditorLayout);
 
   window.addEventListener('resize', debounce(run, 120));
@@ -851,10 +942,12 @@ function bindEditorLayoutRefresh() {
     if (pane) editorLayoutObserver.observe(pane);
     const meta = $('#editorMeta');
     if (meta) editorLayoutObserver.observe(meta);
-    const body = document.querySelector('.editor-body');
+    const body = document.querySelector('.studio-workspace') || document.querySelector('.editor-body');
     if (body) editorLayoutObserver.observe(body);
     const mdeContainer = document.querySelector('.EasyMDEContainer');
     if (mdeContainer) editorLayoutObserver.observe(mdeContainer);
+    const main = document.querySelector('.studio-main');
+    if (main) editorLayoutObserver.observe(main);
   }
 
   run();
@@ -881,6 +974,154 @@ function bindMetaCollapse() {
     localStorage.setItem(key, next ? '1' : '0');
     refreshEditorLayout();
   });
+}
+
+function bindStudioChrome() {
+  const shell = $('#studioShell');
+  const workspace = $('#studioWorkspace');
+  const splitter = $('#studioSplitter');
+  const navBtn = $('#navCollapseBtn');
+  const outlineBtn = $('#outlineCollapseBtn');
+  const mobileNavBtn = $('#btnToggleNav');
+  const mobileOutlineBtn = $('#btnToggleOutline');
+  const docSearch = $('#docSearch');
+  const footAddTag = $('#footAddTag');
+  const btnGenSummary = $('#btnGenSummary');
+
+  if (navBtn && shell) {
+    navBtn.addEventListener('click', () => {
+      shell.classList.toggle('is-nav-collapsed');
+      localStorage.setItem('studio_nav_collapsed', shell.classList.contains('is-nav-collapsed') ? '1' : '0');
+      refreshEditorLayout();
+    });
+    if (localStorage.getItem('studio_nav_collapsed') === '1') shell.classList.add('is-nav-collapsed');
+  }
+
+  if (outlineBtn && shell) {
+    outlineBtn.addEventListener('click', () => {
+      shell.classList.toggle('is-outline-collapsed');
+      localStorage.setItem('studio_outline_collapsed', shell.classList.contains('is-outline-collapsed') ? '1' : '0');
+      refreshEditorLayout();
+    });
+    if (localStorage.getItem('studio_outline_collapsed') === '1') shell.classList.add('is-outline-collapsed');
+  }
+
+  if (mobileNavBtn && shell) {
+    mobileNavBtn.addEventListener('click', () => {
+      shell.classList.toggle('is-mobile-nav-open');
+      shell.classList.remove('is-mobile-outline-open');
+    });
+  }
+  if (mobileOutlineBtn && shell) {
+    mobileOutlineBtn.addEventListener('click', () => {
+      shell.classList.toggle('is-mobile-outline-open');
+      shell.classList.remove('is-mobile-nav-open');
+    });
+  }
+
+  if (docSearch) {
+    docSearch.addEventListener('input', () => {
+      state.docSearch = docSearch.value;
+      renderDocList(state.docSearch);
+    });
+  }
+
+  if (footAddTag) {
+    footAddTag.addEventListener('click', () => {
+      const meta = $('#editorMeta');
+      if (meta) meta.classList.remove('is-collapsed');
+      const nav = $('#studioNav');
+      if (nav) nav.scrollTop = nav.scrollHeight;
+      $('#tagInput')?.focus();
+      if (window.matchMedia('(max-width: 960px)').matches && shell) {
+        shell.classList.add('is-mobile-nav-open');
+      }
+    });
+  }
+
+  if (btnGenSummary) {
+    btnGenSummary.addEventListener('click', () => {
+      const content = getContent();
+      if (!content.trim()) {
+        showToast('正文为空，无法生成摘要', 'error');
+        return;
+      }
+      state.data.summary = extractSummary(content, 120);
+      renderSummaryPreview();
+      showToast('摘要已生成');
+    });
+  }
+
+  if (splitter && workspace) {
+    let dragging = false;
+    const onMove = e => {
+      if (!dragging) return;
+      const rect = workspace.getBoundingClientRect();
+      const pct = ((e.clientX - rect.left) / rect.width) * 100;
+      const clamped = Math.min(78, Math.max(22, pct));
+      workspace.style.gridTemplateColumns = `minmax(0, ${clamped}fr) var(--studio-splitter) minmax(0, ${100 - clamped}fr)`;
+    };
+    const onUp = () => {
+      if (!dragging) return;
+      dragging = false;
+      splitter.classList.remove('is-dragging');
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      refreshEditorLayout();
+    };
+    splitter.addEventListener('mousedown', e => {
+      dragging = true;
+      splitter.classList.add('is-dragging');
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+      e.preventDefault();
+    });
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  }
+
+  bindSyncScroll();
+}
+
+function bindSyncScroll() {
+  const previewPane = $('#previewPane');
+  if (!previewPane) return;
+
+  const getCmScroller = () => {
+    if (!state.mde || !state.mde.codemirror) return null;
+    return state.mde.codemirror.getScrollerElement();
+  };
+
+  previewPane.addEventListener('scroll', () => {
+    if (state.syncScrollLock || state.editorMode !== 'markdown') return;
+    const scroller = getCmScroller();
+    if (!scroller) return;
+    const maxP = previewPane.scrollHeight - previewPane.clientHeight;
+    const maxC = scroller.scrollHeight - scroller.clientHeight;
+    if (maxP <= 0 || maxC <= 0) return;
+    state.syncScrollLock = true;
+    scroller.scrollTop = (previewPane.scrollTop / maxP) * maxC;
+    requestAnimationFrame(() => { state.syncScrollLock = false; });
+  });
+
+  const bindCm = () => {
+    if (!state.mde || !state.mde.codemirror) return;
+    const scroller = getCmScroller();
+    if (!scroller || scroller.dataset.syncBound) return;
+    scroller.dataset.syncBound = '1';
+    scroller.addEventListener('scroll', () => {
+      if (state.syncScrollLock || state.editorMode !== 'markdown') return;
+      const maxC = scroller.scrollHeight - scroller.clientHeight;
+      const maxP = previewPane.scrollHeight - previewPane.clientHeight;
+      if (maxC <= 0 || maxP <= 0) return;
+      state.syncScrollLock = true;
+      previewPane.scrollTop = (scroller.scrollTop / maxC) * maxP;
+      requestAnimationFrame(() => { state.syncScrollLock = false; });
+    });
+  };
+
+  bindCm();
+  setTimeout(bindCm, 500);
 }
 
 function setupEasyMDE() {
@@ -912,7 +1153,6 @@ function setupEasyMDE() {
         title: '上传图片',
       },
       'horizontal-rule', '|',
-      'preview', 'side-by-side', 'fullscreen', '|',
       'guide',
     ],
   });
@@ -944,12 +1184,14 @@ function setupEasyMDE() {
   setupEasyMDE();
   bindEditorLayoutRefresh();
   bindMetaCollapse();
+  bindStudioChrome();
   bindEditorModeSwitch();
   setupDragAndPaste();
   bindTagPicker();
   bindCounterPanel();
   renderEditorCounter();
   loadAvailableTags();
+  loadDocList();
 
   ['title'].forEach(id => {
     $('#' + id).addEventListener('input', updatePreview);
@@ -965,6 +1207,19 @@ function setupEasyMDE() {
   $('#btnPublish').addEventListener('click', publish);
   $('#btnDelete').addEventListener('click', deletePost);
   $('#btnPreview').addEventListener('click', () => {
+    const shell = $('#studioShell');
+    if (shell) {
+      if (shell.classList.contains('is-preview-only')) {
+        shell.classList.remove('is-preview-only');
+        shell.classList.add('is-edit-only');
+      } else if (shell.classList.contains('is-edit-only')) {
+        shell.classList.remove('is-edit-only');
+      } else {
+        shell.classList.add('is-preview-only');
+      }
+      refreshEditorLayout();
+      return;
+    }
     document.querySelectorAll('.editor-pane').forEach(el => el.classList.toggle('preview-mode'));
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

将后台写文章页面重构为类似文档平台的「工作室」布局，并修复 Markdown 编辑区无法滚动的问题。

## 新界面结构

```
┌────────────┬──────────────────────────────┬──────────┐
│  文章列表   │  标题                         │   目录   │
│  + 搜索    ├──────────────┬───────────────┤  (TOC)   │
│            │    编辑      │     预览      │          │
│  文章信息   │  (Markdown)  │  (实时渲染)   │          │
│  标签/摘要  ├──────────────┴───────────────┤          │
│            │  + 添加标签  │  生成摘要      │          │
└────────────┴──────────────────────────────┴──────────┘
```

## 主要能力

- **左栏**：文章列表（可搜索）、当前文章高亮、底部文章信息（作者/封面/slug/标签/摘要）
- **中栏**：大标题输入 + 编辑/预览并排，中间分隔条可拖拽调宽
- **右栏**：从正文 `h2/h3/h4` 自动生成目录，点击跳转预览区对应位置
- **滚动同步**：编辑区与预览区按比例同步滚动
- **底部快捷操作**：`+ 添加标签`、`生成摘要`
- **移动端**：侧栏抽屉、预览/编辑切换

## 滚动修复（保留）

- flex 高度链 + `refreshEditorLayout()` + `ResizeObserver`

## 变更文件

- `admin/editor.html`
- `assets/css/admin.css`
- `assets/js/editor.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53890161-a286-43a2-9d7b-d41551c87404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53890161-a286-43a2-9d7b-d41551c87404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

