### PR TITLE
feat(admin): 编辑页工作室布局 + 专栏 + 移动端富文本

### DIFF
--- a/admin/editor.html
+++ b/admin/editor.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>编辑文章</title>
-  <link rel="stylesheet" href="../assets/css/common.css?v=20260615120000">
-  <link rel="stylesheet" href="../assets/css/admin.css?v=20260615120000">
-  <link rel="stylesheet" href="../assets/css/post.css?v=20260615120000">
+  <link rel="stylesheet" href="../assets/css/common.css?v=20260615140000">
+  <link rel="stylesheet" href="../assets/css/admin.css?v=20260615140000">
+  <link rel="stylesheet" href="../assets/css/post.css?v=20260615140000">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde@2.18.0/dist/easymde.min.css">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="../manifest.webmanifest">
@@ -72,6 +72,20 @@
           <label class="studio-field">作者 <input id="author" placeholder="作者"></label>
           <label class="studio-field">封面 <input id="cover" placeholder="封面图 URL"></label>
           <label class="studio-field">slug <input id="slug" placeholder="自动生成"></label>
+          <div class="editor-series-field" id="seriesField">
+            <span class="editor-meta-label">专栏</span>
+            <div class="editor-selected-tags" id="selectedSeries" aria-live="polite"></div>
+            <div class="editor-tag-input-row">
+              <input id="seriesInput" placeholder="输入专栏名，或从下方选择" list="seriesNameList" autocomplete="off">
+              <datalist id="seriesNameList"></datalist>
+              <button class="btn btn-secondary" id="addSeriesBtn" type="button">加入专栏</button>
+            </div>
+            <div class="editor-tag-suggestions" id="seriesSuggestions"></div>
+            <label class="studio-field studio-series-order" id="seriesOrderWrap" hidden>
+              专栏内排序
+              <input id="seriesOrder" type="number" min="1" step="1" placeholder="如 1、2、3（越小越靠前）">
+            </label>
+          </div>
           <div class="studio-field studio-summary-field">
             <span class="editor-meta-label">摘要</span>
             <p class="studio-summary-text" id="summaryPreview">发布时自动从正文提取，也可点下方「生成摘要」</p>
@@ -114,6 +128,7 @@
           </div>
           <footer class="studio-panel-foot">
             <button type="button" class="studio-foot-btn" id="footAddTag">+ 添加标签</button>
+            <button type="button" class="studio-foot-btn" id="footAddSeries">+ 加入专栏</button>
             <button type="button" class="studio-foot-btn studio-foot-btn-ai" id="btnGenSummary">生成摘要</button>
           </footer>
         </section>
@@ -142,6 +157,6 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/easymde@2.18.0/dist/easymde.min.js"></script>
-  <script type="module" src="../assets/js/editor.js?v=20260615120000"></script>
+  <script type="module" src="../assets/js/editor.js?v=20260615140000"></script>
 </body>
 </html>

--- a/admin/editor.html
+++ b/admin/editor.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="referrer" content="no-referrer-when-downgrade">
   <title>编辑文章</title>
-  <link rel="stylesheet" href="../assets/css/common.css?v=20260615140000">
-  <link rel="stylesheet" href="../assets/css/admin.css?v=20260615140000">
-  <link rel="stylesheet" href="../assets/css/post.css?v=20260615140000">
+  <link rel="stylesheet" href="../assets/css/common.css?v=20260618180000">
+  <link rel="stylesheet" href="../assets/css/admin.css?v=20260618180000">
+  <link rel="stylesheet" href="../assets/css/post.css?v=20260618180000">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde@2.18.0/dist/easymde.min.css">
   <script>(function(){var s=localStorage;var t=s.getItem('blog_theme')||'auto';var d=t==='auto'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;var p=s.getItem('blog_preset')||'jianshu';var h=document.documentElement;h.setAttribute('data-preset',p);h.setAttribute('data-mode',d);h.setAttribute('data-theme',d);h.dataset.themeChoice=t;})();</script>
   <link rel="manifest" href="../manifest.webmanifest">
@@ -22,93 +22,116 @@
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
         后台
       </a>
-      <a class="btn btn-primary studio-btn-new" href="./editor.html">新建</a>
-      <button type="button" class="studio-icon-btn studio-only-mobile" id="btnToggleNav" title="文章列表" aria-label="文章列表">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 6h16M4 12h16M4 18h10"/></svg>
-      </button>
+      <a class="btn btn-primary studio-btn-new studio-only-desktop" href="./editor.html">新建</a>
     </div>
     <div class="studio-header-center">
       <span class="editor-status" id="status">未登录</span>
     </div>
     <div class="studio-header-right">
-      <div class="editor-mode-switch" role="tablist" aria-label="编辑模式">
+      <div class="editor-mode-switch studio-only-desktop" role="tablist" aria-label="编辑模式">
         <button type="button" class="editor-mode-btn is-active" data-mode="markdown" role="tab" aria-selected="true" title="Markdown 源码">Markdown</button>
         <button type="button" class="editor-mode-btn" data-mode="rich" role="tab" aria-selected="false" title="富文本模式">富文本</button>
       </div>
-      <div class="editor-toggle-row">
+      <div class="editor-toggle-row studio-only-desktop">
         <label><input type="checkbox" id="draftToggle"> 草稿</label>
         <label><input type="checkbox" id="pinnedToggle"> 置顶</label>
         <label title="需有封面"><input type="checkbox" id="carouselToggle"> 轮播</label>
       </div>
-      <button id="themeToggle" class="icon-btn" title="切换主题">
+      <button id="themeToggle" class="icon-btn studio-only-desktop" title="切换主题">
         <svg class="icon-light" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
         <svg class="icon-dark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
         <svg class="icon-auto" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/></svg>
       </button>
-      <button class="btn btn-secondary studio-only-mobile" id="btnPreview" type="button">预览</button>
-      <button class="btn btn-secondary studio-only-mobile" id="btnToggleOutline" type="button" title="目录">目录</button>
-      <button class="btn btn-secondary" id="btnDelete" style="display:none" type="button">删除</button>
-      <button class="btn btn-primary" id="btnPublish" type="button">发布</button>
+      <button class="btn btn-secondary studio-only-desktop" id="btnDelete" style="display:none" type="button">删除</button>
+      <button class="btn btn-primary studio-only-desktop" id="btnPublish" type="button">发布</button>
     </div>
   </header>
 
   <div class="studio-shell" id="studioShell">
+    <div class="studio-drawer-backdrop" id="studioDrawerBackdrop" hidden></div>
+
     <aside class="studio-nav" id="studioNav">
       <div class="studio-side-head">
-        <strong>文章</strong>
-        <button type="button" class="studio-side-toggle" id="navCollapseBtn" title="收起侧栏" aria-label="收起侧栏">‹</button>
-      </div>
-      <div class="studio-nav-search">
-        <input id="docSearch" type="search" placeholder="搜索标题或 slug…" autocomplete="off">
-      </div>
-      <nav class="studio-doc-list" id="docList" aria-label="文章列表"></nav>
-
-      <div class="studio-nav-meta" id="editorMeta">
-        <div class="editor-meta-toolbar">
-          <span>文章信息</span>
-          <button type="button" class="editor-meta-collapse" id="metaCollapseBtn" aria-expanded="true" aria-controls="editorMeta">收起</button>
+        <div class="studio-nav-tabs" role="tablist" aria-label="侧栏">
+          <button type="button" class="studio-nav-tab is-active" data-nav-tab="list" role="tab" aria-selected="true">列表</button>
+          <button type="button" class="studio-nav-tab" data-nav-tab="settings" role="tab" aria-selected="false">设置</button>
         </div>
-        <div class="studio-meta-body">
-          <label class="studio-field">作者 <input id="author" placeholder="作者"></label>
-          <label class="studio-field">封面 <input id="cover" placeholder="封面图 URL"></label>
-          <label class="studio-field">slug <input id="slug" placeholder="自动生成"></label>
-          <div class="editor-series-field" id="seriesField">
-            <span class="editor-meta-label">专栏</span>
-            <div class="editor-selected-tags" id="selectedSeries" aria-live="polite"></div>
-            <div class="editor-tag-input-row">
-              <input id="seriesInput" placeholder="输入专栏名，或从下方选择" list="seriesNameList" autocomplete="off">
-              <datalist id="seriesNameList"></datalist>
-              <button class="btn btn-secondary" id="addSeriesBtn" type="button">加入专栏</button>
+        <button type="button" class="studio-side-toggle studio-only-desktop" id="navCollapseBtn" title="收起侧栏" aria-label="收起侧栏">‹</button>
+        <button type="button" class="studio-side-close studio-only-mobile" id="navCloseBtn" aria-label="关闭">×</button>
+      </div>
+
+      <div class="studio-nav-panel is-active" data-nav-panel="list">
+        <div class="studio-nav-search">
+          <input id="docSearch" type="search" placeholder="搜索标题或 slug…" autocomplete="off">
+        </div>
+        <nav class="studio-doc-list" id="docList" aria-label="文章列表"></nav>
+      </div>
+
+      <div class="studio-nav-panel" data-nav-panel="settings" id="editorMeta">
+        <div class="studio-meta-scroll">
+          <section class="studio-meta-section">
+            <h3 class="studio-meta-section-title">基础信息</h3>
+            <div class="studio-meta-grid">
+              <label class="studio-field">作者<input id="author" placeholder="作者" autocomplete="off"></label>
+              <label class="studio-field">slug<input id="slug" placeholder="自动生成" autocomplete="off"></label>
+              <label class="studio-field studio-field-full">封面<input id="cover" placeholder="封面图 URL" autocomplete="off"></label>
             </div>
-            <div class="editor-tag-suggestions" id="seriesSuggestions"></div>
-            <label class="studio-field studio-series-order" id="seriesOrderWrap" hidden>
-              专栏内排序
-              <input id="seriesOrder" type="number" min="1" step="1" placeholder="如 1、2、3（越小越靠前）">
-            </label>
-          </div>
-          <div class="studio-field studio-summary-field">
-            <span class="editor-meta-label">摘要</span>
-            <p class="studio-summary-text" id="summaryPreview">发布时自动从正文提取，也可点下方「生成摘要」</p>
-          </div>
-          <div class="editor-tag-field">
-            <span class="editor-meta-label">标签</span>
-            <input id="tags" type="hidden">
-            <div class="editor-selected-tags" id="selectedTags" aria-live="polite"></div>
-            <div class="editor-tag-input-row">
-              <input id="tagInput" placeholder="输入标签后回车">
-              <button class="btn btn-secondary" id="addTagBtn" type="button">添加</button>
+            <div class="studio-summary-box">
+              <span class="editor-meta-label">摘要</span>
+              <p class="studio-summary-text" id="summaryPreview">发布时自动从正文提取，也可点「生成摘要」</p>
+              <button type="button" class="studio-inline-btn" id="btnGenSummaryMeta">生成摘要</button>
             </div>
-            <div class="editor-tag-suggestions" id="tagSuggestions"></div>
-          </div>
-          <div class="editor-counter-field" id="counterField" hidden>
-            <span class="editor-meta-label">独立计数器（saobby）</span>
+          </section>
+
+          <section class="studio-meta-section">
+            <h3 class="studio-meta-section-title">专栏</h3>
+            <div class="editor-series-field" id="seriesField">
+              <div class="editor-selected-tags" id="selectedSeries" aria-live="polite"></div>
+              <div class="editor-tag-input-row">
+                <input id="seriesInput" placeholder="专栏名称" list="seriesNameList" autocomplete="off">
+                <datalist id="seriesNameList"></datalist>
+                <button class="btn btn-secondary" id="addSeriesBtn" type="button">加入</button>
+              </div>
+              <div class="editor-tag-suggestions" id="seriesSuggestions"></div>
+              <label class="studio-field studio-series-order" id="seriesOrderWrap" hidden>
+                专栏内排序<input id="seriesOrder" type="number" min="1" step="1" placeholder="1、2、3…">
+              </label>
+            </div>
+          </section>
+
+          <section class="studio-meta-section">
+            <h3 class="studio-meta-section-title">标签</h3>
+            <div class="editor-tag-field">
+              <input id="tags" type="hidden">
+              <div class="editor-selected-tags" id="selectedTags" aria-live="polite"></div>
+              <div class="editor-tag-input-row">
+                <input id="tagInput" placeholder="输入后回车" autocomplete="off">
+                <button class="btn btn-secondary" id="addTagBtn" type="button">添加</button>
+              </div>
+              <div class="editor-tag-suggestions" id="tagSuggestions"></div>
+            </div>
+          </section>
+
+          <section class="studio-meta-section">
+            <h3 class="studio-meta-section-title">发布选项</h3>
+            <div class="studio-check-grid studio-only-mobile">
+              <label class="studio-check"><input type="checkbox" id="draftToggleMobile"> 草稿</label>
+              <label class="studio-check"><input type="checkbox" id="pinnedToggleMobile"> 置顶</label>
+              <label class="studio-check"><input type="checkbox" id="carouselToggleMobile"> 轮播</label>
+            </div>
+            <p class="studio-meta-hint studio-only-mobile">移动端使用富文本编辑；发布选项与桌面端同步。</p>
+            <button type="button" class="btn btn-secondary studio-btn-block studio-only-mobile" id="btnDeleteMobile" style="display:none">删除文章</button>
+          </section>
+
+          <section class="editor-counter-field studio-meta-section" id="counterField" hidden>
+            <h3 class="studio-meta-section-title">独立计数器</h3>
             <div class="editor-counter-row">
-              <button type="button" class="btn btn-secondary" id="counterCreateBtn">创建计数器…</button>
+              <button type="button" class="btn btn-secondary" id="counterCreateBtn">创建…</button>
               <button type="button" class="btn" id="counterPasteBtn">粘贴 URL…</button>
               <button type="button" class="btn" id="counterClearBtn" hidden>清除</button>
             </div>
             <div class="editor-counter-summary" id="counterSummary"></div>
-          </div>
+          </section>
         </div>
       </div>
     </aside>
@@ -120,22 +143,22 @@
 
       <div class="studio-workspace" id="studioWorkspace">
         <section class="studio-panel studio-panel-source">
-          <header class="studio-panel-head"><span>编辑</span></header>
+          <header class="studio-panel-head studio-only-desktop"><span>编辑</span></header>
           <div class="studio-panel-body studio-source-body">
             <textarea class="editor-textarea" id="content" placeholder="开始用 Markdown 写作。支持拖拽 / 粘贴上传图片"></textarea>
             <div id="vditorHost" class="editor-vditor-host" hidden></div>
             <div id="dropHint" class="editor-drop-hint" hidden>松开以上传图片</div>
           </div>
-          <footer class="studio-panel-foot">
+          <footer class="studio-panel-foot studio-only-desktop">
             <button type="button" class="studio-foot-btn" id="footAddTag">+ 添加标签</button>
             <button type="button" class="studio-foot-btn" id="footAddSeries">+ 加入专栏</button>
             <button type="button" class="studio-foot-btn studio-foot-btn-ai" id="btnGenSummary">生成摘要</button>
           </footer>
         </section>
 
-        <div class="studio-splitter" id="studioSplitter" role="separator" aria-orientation="vertical" aria-label="调整编辑与预览宽度"></div>
+        <div class="studio-splitter studio-only-desktop" id="studioSplitter" role="separator" aria-orientation="vertical" aria-label="调整编辑与预览宽度"></div>
 
-        <section class="studio-panel studio-panel-preview">
+        <section class="studio-panel studio-panel-preview studio-only-desktop">
           <header class="studio-panel-head"><span>预览</span></header>
           <div class="studio-panel-body editor-preview" id="previewPane">
             <h1 class="article-title" id="previewTitle">预览</h1>
@@ -145,7 +168,7 @@
       </div>
     </main>
 
-    <aside class="studio-outline" id="studioOutline">
+    <aside class="studio-outline studio-only-desktop" id="studioOutline">
       <div class="studio-side-head">
         <strong>目录</strong>
         <button type="button" class="studio-side-toggle" id="outlineCollapseBtn" title="收起目录" aria-label="收起目录">›</button>
@@ -156,7 +179,19 @@
     </aside>
   </div>
 
+  <nav class="studio-mobile-bar studio-only-mobile" aria-label="移动端操作">
+    <button type="button" class="studio-mobile-btn" id="btnMobileList">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 6h16M4 12h16M4 18h10"/></svg>
+      <span>文章</span>
+    </button>
+    <button type="button" class="studio-mobile-btn" id="btnMobileSettings">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+      <span>设置</span>
+    </button>
+    <button type="button" class="studio-mobile-btn studio-mobile-btn-primary" id="btnPublishMobile">发布</button>
+  </nav>
+
   <script src="https://cdn.jsdelivr.net/npm/easymde@2.18.0/dist/easymde.min.js"></script>
-  <script type="module" src="../assets/js/editor.js?v=20260615140000"></script>
+  <script type="module" src="../assets/js/editor.js?v=20260618180000"></script>
 </body>
 </html>

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1278,6 +1278,15 @@ html[data-mode="dark"] .editor-vditor-host .vditor-toolbar__item .vditor-tooltip
   color: var(--text-tertiary);
   border: 1px solid var(--border);
 }
+.studio-doc-badge.studio-doc-series {
+  max-width: 92px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--primary);
+  border-color: color-mix(in srgb, var(--primary) 25%, var(--border));
+  background: color-mix(in srgb, var(--primary) 8%, var(--bg-elev));
+}
 .studio-nav-empty {
   padding: 16px 14px;
   font-size: 12px;
@@ -1325,12 +1334,19 @@ html[data-mode="dark"] .editor-vditor-host .vditor-toolbar__item .vditor-tooltip
   outline: none;
   border-color: var(--primary);
 }
-.studio-summary-text {
-  margin: 0;
-  font-size: 12px;
-  line-height: 1.5;
-  color: var(--text-tertiary);
-  word-break: break-word;
+.editor-series-field {
+  display: grid;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+}
+.studio-series-order {
+  margin-top: 2px;
+}
+.studio-series-order input {
+  max-width: 120px;
 }
 
 .studio-main {

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1143,7 +1143,6 @@ html[data-mode="dark"] .editor-vditor-host .vditor-toolbar__item .vditor-tooltip
   justify-content: center;
   cursor: pointer;
 }
-.studio-only-mobile { display: none; }
 
 .studio-shell {
   display: flex;
@@ -1294,59 +1293,225 @@ html[data-mode="dark"] .editor-vditor-host .vditor-toolbar__item .vditor-tooltip
   margin: 0;
 }
 
-.studio-nav-meta {
-  flex-shrink: 0;
-  max-height: 42vh;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  border-top: 1px solid var(--border);
+.studio-only-desktop { display: inline-flex; }
+.studio-only-mobile { display: none; }
+
+.studio-nav-tabs {
+  display: inline-flex;
+  gap: 4px;
+  padding: 3px;
+  border-radius: 8px;
   background: var(--bg-soft);
+  border: 1px solid var(--border);
 }
-.studio-nav-meta.is-collapsed { max-height: 40px; }
-.studio-nav-meta .editor-meta-toolbar {
-  padding: 8px 12px 0;
-  margin-bottom: 0;
+.studio-nav-tab {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 5px 12px;
+  border-radius: 6px;
+  cursor: pointer;
 }
-.studio-meta-body {
-  padding: 8px 12px 12px;
+.studio-nav-tab.is-active {
+  background: var(--bg);
+  color: var(--primary);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+.studio-side-close {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--text-tertiary);
+  font-size: 22px;
+  line-height: 1;
+  padding: 0 4px;
+  cursor: pointer;
+}
+
+.studio-nav-panel {
+  display: none;
+  flex: 1 1 0;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+}
+.studio-nav-panel.is-active {
+  display: flex;
+}
+
+.studio-meta-scroll {
+  flex: 1 1 0;
+  min-height: 0;
   overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 12px;
+  display: grid;
+  gap: 14px;
+}
+.studio-meta-section {
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--bg-soft);
   display: grid;
   gap: 10px;
 }
-.studio-nav-meta.is-collapsed .studio-meta-body { display: none; }
+.studio-meta-section-title {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-main);
+  letter-spacing: 0.02em;
+}
+.studio-meta-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+.studio-field-full { grid-column: 1 / -1; }
+.studio-summary-box {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 8px;
+  background: var(--bg);
+  border: 1px dashed var(--border);
+}
+.studio-inline-btn {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text-secondary);
+  font-size: 12px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  justify-self: start;
+}
+.studio-inline-btn:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+.studio-check-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+.studio-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+}
+.studio-meta-hint {
+  margin: 0;
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+  line-height: 1.5;
+}
+.studio-btn-block { width: 100%; }
+
 .studio-field {
   display: grid;
-  gap: 4px;
+  gap: 5px;
   font-size: 12px;
   color: var(--text-secondary);
+  font-weight: 500;
 }
 .studio-field input {
   width: 100%;
-  padding: 6px 10px;
-  font-size: 12px;
+  padding: 8px 10px;
+  font-size: 13px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 8px;
   background: var(--bg);
   color: var(--text-main);
 }
 .studio-field input:focus {
   outline: none;
   border-color: var(--primary);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 15%, transparent);
 }
-.editor-series-field {
+.editor-series-field,
+.editor-tag-field {
   display: grid;
   gap: 8px;
-  padding: 10px 12px;
-  border-radius: 10px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  border-radius: 0;
+}
+.studio-summary-text {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  word-break: break-word;
+}
+.studio-series-order input { max-width: 100%; }
+
+.studio-drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 35;
+  background: rgba(0, 0, 0, 0.35);
+}
+.studio-drawer-backdrop[hidden] { display: none !important; }
+
+/* 富文本 / 移动端：单栏编辑，隐藏预览与目录 */
+.studio-shell.is-rich-mode .studio-workspace {
+  grid-template-columns: minmax(0, 1fr) !important;
+}
+.studio-shell.is-rich-mode .studio-splitter,
+.studio-shell.is-rich-mode .studio-panel-preview {
+  display: none !important;
+}
+.studio-shell.is-rich-mode .studio-outline {
+  display: none !important;
+}
+
+.studio-mobile-bar {
+  display: none;
+  flex-shrink: 0;
+  align-items: stretch;
+  gap: 8px;
+  padding: 8px 12px calc(8px + env(safe-area-inset-bottom));
+  border-top: 1px solid var(--border);
   background: var(--bg);
+  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.06);
+}
+.studio-mobile-btn {
+  flex: 1;
+  appearance: none;
   border: 1px solid var(--border);
+  background: var(--bg-soft);
+  color: var(--text-secondary);
+  border-radius: 10px;
+  padding: 8px 6px;
+  font-size: 12px;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  cursor: pointer;
 }
-.studio-series-order {
-  margin-top: 2px;
-}
-.studio-series-order input {
-  max-width: 120px;
+.studio-mobile-btn-primary {
+  flex: 1.4;
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  flex-direction: row;
 }
 
 .studio-main {
@@ -1549,47 +1714,92 @@ html[data-mode="dark"] .studio-foot-btn-ai {
 }
 
 @media (max-width: 960px) {
-  .studio-only-mobile { display: inline-flex; }
-  .studio-icon-btn { display: inline-flex; }
-  .editor-studio { --studio-nav-w: 0px; --studio-outline-w: 0px; }
-  .studio-nav,
-  .studio-outline {
+  .studio-only-desktop { display: none !important; }
+  .studio-only-mobile { display: flex; }
+
+  .editor-studio.is-mobile-editor { --studio-nav-w: 0px; --studio-outline-w: 0px; }
+  .editor-studio.is-mobile-editor .studio-header {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    min-height: 48px;
+  }
+  .editor-studio.is-mobile-editor .studio-header-left,
+  .editor-studio.is-mobile-editor .studio-header-right {
+    flex-wrap: nowrap;
+  }
+  .editor-studio.is-mobile-editor .studio-header-center {
+    justify-content: flex-start;
+    min-width: 0;
+  }
+  .editor-studio.is-mobile-editor .studio-header .editor-status {
+    font-size: 11px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .editor-studio.is-mobile-editor .studio-header-right {
+    display: none;
+  }
+
+  .editor-studio.is-mobile-editor .studio-nav {
     position: fixed;
-    top: 52px;
+    top: 0;
+    left: 0;
     bottom: 0;
-    z-index: 40;
-    width: min(86vw, 300px) !important;
+    z-index: 45;
+    width: min(92vw, 360px) !important;
+    max-width: 360px;
     opacity: 1 !important;
     pointer-events: auto !important;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
-  }
-  .studio-nav { left: 0; transform: translateX(-105%); transition: transform 0.22s ease; }
-  .studio-outline { right: 0; left: auto; transform: translateX(105%); border-left: 1px solid var(--border); }
-  .studio-shell.is-mobile-nav-open .studio-nav { transform: translateX(0); }
-  .studio-shell.is-mobile-outline-open .studio-outline { transform: translateX(0); }
-  .studio-shell.is-nav-collapsed .studio-nav,
-  .studio-shell.is-outline-collapsed .studio-outline {
+    box-shadow: 8px 0 32px rgba(0, 0, 0, 0.14);
     transform: translateX(-105%);
+    transition: transform 0.22s ease;
   }
-  .studio-shell.is-outline-collapsed.is-mobile-outline-open .studio-outline {
+  .editor-studio.is-mobile-editor .studio-shell.is-mobile-nav-open .studio-nav {
     transform: translateX(0);
   }
-  .studio-workspace {
-    grid-template-columns: minmax(0, 1fr) 0 minmax(0, 1fr);
+  .editor-studio.is-mobile-editor .studio-side-head {
+    padding-top: calc(10px + env(safe-area-inset-top));
   }
-  .studio-splitter { display: none; }
-  .studio-shell.is-preview-only .studio-panel-source { display: none; }
-  .studio-shell.is-preview-only .studio-panel-preview { grid-column: 1 / -1; }
-  .studio-shell.is-edit-only .studio-panel-preview { display: none; }
-  .studio-shell.is-edit-only .studio-panel-source { grid-column: 1 / -1; }
-  .studio-header-center { order: 10; flex: 1 0 100%; }
+  .editor-studio.is-mobile-editor .studio-meta-grid {
+    grid-template-columns: 1fr;
+  }
+  .editor-studio.is-mobile-editor .studio-check-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .editor-studio.is-mobile-editor .studio-workspace {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+  .editor-studio.is-mobile-editor .EasyMDEContainer,
+  .editor-studio.is-mobile-editor .editor-textarea {
+    display: none !important;
+  }
+  .editor-studio.is-mobile-editor .editor-vditor-host {
+    padding: 0;
+  }
+  .editor-studio.is-mobile-editor .editor-vditor-host .vditor {
+    border: none;
+    border-radius: 0;
+  }
+  .editor-studio.is-mobile-editor .studio-titlebar {
+    padding: 10px 14px 8px;
+    border-bottom: none;
+  }
+  .editor-studio.is-mobile-editor .studio-title {
+    font-size: 18px;
+  }
+  .editor-studio.is-mobile-editor .studio-mobile-bar {
+    display: flex;
+  }
 }
 
 @media (max-width: 640px) {
-  .studio-header { padding: 8px 10px; gap: 8px; }
-  .studio-header-right .editor-toggle-row { display: none; }
-  .studio-titlebar { padding: 12px 14px 8px; }
-  .studio-title { font-size: 19px; }
+  .studio-meta-scroll { padding: 10px; gap: 10px; }
+  .studio-meta-section { padding: 10px; }
 }
 
 /* ---------- 模态框 ---------- */

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -56,6 +56,9 @@ const state = {
   editorMode: 'markdown',  // markdown | rich
   selectedTags: [],
   availableTags: [],
+  selectedSeries: '',
+  seriesOrder: '',
+  availableSeries: [],
   counter: { img: '', dashboard: '' }, // 文章独立 saobby 计数器
   docList: [],
   docSearch: '',
@@ -118,6 +121,7 @@ async function loadPost(slug) {
     $('#draftToggle').checked = !!data.draft;
     $('#pinnedToggle').checked = !!data.pinned;
     $('#carouselToggle').checked = !!data.carousel;
+    setEditorSeries(data.series || '', data.seriesOrder);
     setEditorCounter(data.counter || { img: '', dashboard: '' });
     setContent(content);
     document.title = `编辑：${data.title || slug}`;
@@ -219,10 +223,22 @@ function renderDocList(filter = '') {
            href="./editor.html?slug=${encodeURIComponent(p.slug)}"
            title="${escapeHtml(p.title || p.slug)}">
           <span class="studio-doc-title">${escapeHtml(p.title || p.slug)}</span>
+          ${p.series ? `<span class="studio-doc-badge studio-doc-series">${escapeHtml(p.series)}</span>` : ''}
           ${p.draft ? '<span class="studio-doc-badge">草稿</span>' : ''}
         </a>
       `).join('')
     : '<p class="studio-nav-empty">没有匹配的文章</p>';
+
+  refreshSeriesFromDocList();
+}
+
+function refreshSeriesFromDocList() {
+  const names = state.docList.map(p => normalizeSeriesName(p.series)).filter(Boolean);
+  if (state.selectedSeries) names.push(state.selectedSeries);
+  state.availableSeries = [...new Set([...state.availableSeries, ...names])]
+    .sort((a, b) => a.localeCompare(b, 'zh-CN'));
+  renderSeriesPicker();
+  renderSeriesDatalist();
 }
 
 function toCommaList(s) {
@@ -406,6 +422,160 @@ function bindTagPicker() {
   });
 }
 
+function normalizeSeriesName(name) {
+  return String(name || '').trim();
+}
+
+function suggestSeriesOrder(seriesName) {
+  const name = normalizeSeriesName(seriesName);
+  if (!name) return '';
+  const inSeries = state.docList.filter(p => normalizeSeriesName(p.series) === name && p.slug !== state.loadedSlug);
+  const max = inSeries.reduce((m, p) => Math.max(m, Number(p.seriesOrder) || 0), 0);
+  return String(max + 1);
+}
+
+function setEditorSeries(series, order) {
+  state.selectedSeries = normalizeSeriesName(series);
+  const orderEl = $('#seriesOrder');
+  const orderWrap = $('#seriesOrderWrap');
+  const input = $('#seriesInput');
+  if (input) input.value = state.selectedSeries;
+  if (orderEl) {
+    const n = order == null || order === '' ? '' : String(order);
+    state.seriesOrder = n;
+    orderEl.value = n;
+  }
+  if (orderWrap) orderWrap.hidden = !state.selectedSeries;
+  renderSeriesPicker();
+  renderSeriesDatalist();
+}
+
+function renderSeriesDatalist() {
+  const list = $('#seriesNameList');
+  if (!list) return;
+  list.innerHTML = state.availableSeries
+    .map(s => `<option value="${escapeHtml(s)}"></option>`)
+    .join('');
+}
+
+function renderSeriesPicker() {
+  const selected = $('#selectedSeries');
+  const suggestions = $('#seriesSuggestions');
+  const orderWrap = $('#seriesOrderWrap');
+  if (!selected || !suggestions) return;
+
+  selected.innerHTML = state.selectedSeries
+    ? `<button class="editor-tag-chip selected" type="button" data-remove-series title="点击移除专栏">
+        ${escapeHtml(state.selectedSeries)}<span>×</span>
+      </button>`
+    : '<span class="editor-tag-empty">尚未加入专栏</span>';
+
+  if (orderWrap) orderWrap.hidden = !state.selectedSeries;
+
+  const q = ($('#seriesInput') && $('#seriesInput').value.trim().toLowerCase()) || '';
+  const names = state.availableSeries
+    .filter(s => s !== state.selectedSeries)
+    .filter(s => !q || s.toLowerCase().includes(q))
+    .slice(0, 24);
+
+  suggestions.innerHTML = names.length
+    ? names.map(s => `<button class="editor-tag-chip" type="button" data-add-series="${escapeHtml(s)}">${escapeHtml(s)}</button>`).join('')
+    : '<span class="editor-tag-empty">输入新专栏名后点「加入专栏」</span>';
+}
+
+function addEditorSeries(raw) {
+  const name = normalizeSeriesName(raw);
+  if (!name) {
+    showToast('请输入专栏名称', 'error');
+    return;
+  }
+  state.selectedSeries = name;
+  if (!state.availableSeries.includes(name)) {
+    state.availableSeries.push(name);
+    state.availableSeries.sort((a, b) => a.localeCompare(b, 'zh-CN'));
+  }
+  const input = $('#seriesInput');
+  if (input) input.value = name;
+  const orderEl = $('#seriesOrder');
+  if (orderEl && !orderEl.value.trim()) {
+    const suggested = suggestSeriesOrder(name);
+    orderEl.value = suggested;
+    state.seriesOrder = suggested;
+  }
+  renderSeriesPicker();
+  renderSeriesDatalist();
+  showToast(`已加入专栏「${name}」`);
+}
+
+function removeEditorSeries() {
+  state.selectedSeries = '';
+  state.seriesOrder = '';
+  const input = $('#seriesInput');
+  const orderEl = $('#seriesOrder');
+  if (input) input.value = '';
+  if (orderEl) orderEl.value = '';
+  renderSeriesPicker();
+}
+
+function bindSeriesPicker() {
+  const input = $('#seriesInput');
+  const addBtn = $('#addSeriesBtn');
+  const selected = $('#selectedSeries');
+  const suggestions = $('#seriesSuggestions');
+  const orderEl = $('#seriesOrder');
+  if (!input || !addBtn || !selected || !suggestions) return;
+
+  addBtn.addEventListener('click', () => addEditorSeries(input.value));
+  input.addEventListener('input', renderSeriesPicker);
+  input.addEventListener('keydown', e => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      addEditorSeries(input.value);
+    }
+  });
+  suggestions.addEventListener('click', e => {
+    const btn = e.target.closest('[data-add-series]');
+    if (btn) addEditorSeries(btn.dataset.addSeries);
+  });
+  selected.addEventListener('click', e => {
+    if (e.target.closest('[data-remove-series]')) removeEditorSeries();
+  });
+  if (orderEl) {
+    orderEl.addEventListener('input', () => {
+      state.seriesOrder = orderEl.value.trim();
+    });
+  }
+}
+
+async function loadAvailableSeries() {
+  try {
+    const idx = await readIndex();
+    const names = [];
+    for (const p of ((idx && idx.data && idx.data.posts) || [])) {
+      const s = normalizeSeriesName(p.series);
+      if (s) names.push(s);
+    }
+    if (state.selectedSeries) names.push(state.selectedSeries);
+    state.availableSeries = [...new Set(names)].sort((a, b) => a.localeCompare(b, 'zh-CN'));
+    renderSeriesPicker();
+    renderSeriesDatalist();
+  } catch (e) {
+    console.warn('专栏列表加载失败', e);
+  }
+}
+
+function focusSeriesPanel() {
+  const meta = $('#editorMeta');
+  const shell = $('#studioShell');
+  if (meta) meta.classList.remove('is-collapsed');
+  if (shell && window.matchMedia('(max-width: 960px)').matches) {
+    shell.classList.add('is-mobile-nav-open');
+  }
+  const field = $('#seriesField');
+  if (field) field.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  $('#seriesInput')?.focus();
+}
+
 function validateBeforePublish({ title, slug, content, tags, summary, allPosts, isUpdate }) {
   const errs = [];
   if (!title.trim()) errs.push('标题不能为空');
@@ -432,6 +602,8 @@ async function publish() {
   const pinned = $('#pinnedToggle').checked;
   const carousel = $('#carouselToggle').checked;
   const summary = state.data.summary || extractSummary(content, 80);
+  const series = normalizeSeriesName(state.selectedSeries || ($('#seriesInput') && $('#seriesInput').value));
+  const seriesOrderRaw = ($('#seriesOrder') && $('#seriesOrder').value.trim()) || state.seriesOrder || '';
   if (carousel && !cover) {
     if (!confirm('当前文章没有封面图，无法进入首页轮播。\n\n继续发布会取消「轮播」勾选。是否继续？')) return;
   }
@@ -466,6 +638,13 @@ async function publish() {
   if (draft) data.draft = true;
   if (pinned) data.pinned = true;
   if (carousel && cover) data.carousel = true;
+  if (series) {
+    data.series = series;
+    if (seriesOrderRaw !== '') {
+      const n = Number(seriesOrderRaw);
+      if (!Number.isNaN(n) && n > 0) data.seriesOrder = n;
+    }
+  }
   const counter = state.counter || {};
   if (counter.img || counter.dashboard) {
     data.counter = {
@@ -533,6 +712,8 @@ async function publish() {
       draft,
       pinned,
       carousel: carousel && !!cover,
+      series: data.series,
+      seriesOrder: data.seriesOrder,
       counter: data.counter,
       path: state.loadedPath,
       removeSlug: isRename ? state.loadedSlug : null,
@@ -564,7 +745,7 @@ async function publish() {
   }
 }
 
-async function updateIndex({ slug, title, date, updated, author, summary, tags, cover, draft, pinned, carousel, counter, path, removeSlug }) {
+async function updateIndex({ slug, title, date, updated, author, summary, tags, cover, draft, pinned, carousel, series, seriesOrder, counter, path, removeSlug }) {
   const idx = await readIndex();
   const data = idx ? idx.data : { posts: [] };
   if (!Array.isArray(data.posts)) data.posts = [];
@@ -579,6 +760,8 @@ async function updateIndex({ slug, title, date, updated, author, summary, tags, 
   if (draft) entry.draft = true;
   if (pinned) entry.pinned = true;
   if (carousel && cover) entry.carousel = true;
+  if (series) entry.series = series;
+  if (seriesOrder != null && !Number.isNaN(Number(seriesOrder))) entry.seriesOrder = Number(seriesOrder);
   if (counter && (counter.img || counter.dashboard)) {
     entry.counter = {
       img: String(counter.img || ''),
@@ -1039,6 +1222,11 @@ function bindStudioChrome() {
     });
   }
 
+  const footAddSeries = $('#footAddSeries');
+  if (footAddSeries) {
+    footAddSeries.addEventListener('click', focusSeriesPanel);
+  }
+
   if (btnGenSummary) {
     btnGenSummary.addEventListener('click', () => {
       const content = getContent();
@@ -1188,9 +1376,11 @@ function setupEasyMDE() {
   bindEditorModeSwitch();
   setupDragAndPaste();
   bindTagPicker();
+  bindSeriesPicker();
   bindCounterPanel();
   renderEditorCounter();
   loadAvailableTags();
+  loadAvailableSeries();
   loadDocList();
 
   ['title'].forEach(id => {
@@ -1233,6 +1423,7 @@ function setupEasyMDE() {
         $('#title').value = d.title || '';
         setContent(d.content || '');
         setEditorTags(toCommaList(d.tags || ''));
+        setEditorSeries(d.series || '', d.seriesOrder);
         $('#cover').value = d.cover || '';
         $('#slug').value = d.slug || '';
       } else {
@@ -1246,6 +1437,8 @@ function setupEasyMDE() {
       title: $('#title').value,
       content: getContent(),
       tags: $('#tags').value,
+      series: state.selectedSeries,
+      seriesOrder: ($('#seriesOrder') && $('#seriesOrder').value) || state.seriesOrder,
       cover: $('#cover').value,
       slug: $('#slug').value,
       savedAt: new Date().toISOString(),

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -127,7 +127,7 @@ async function loadPost(slug) {
     document.title = `编辑：${data.title || slug}`;
     renderSummaryPreview();
     setStatus('已加载', 'saved');
-    $('#btnDelete').style.display = '';
+    syncDeleteButtons(true);
     updatePreview();
     refreshEditorLayout();
   } catch (e) {
@@ -564,16 +564,110 @@ async function loadAvailableSeries() {
   }
 }
 
-function focusSeriesPanel() {
-  const meta = $('#editorMeta');
+const MOBILE_EDITOR_MQ = window.matchMedia('(max-width: 960px)');
+
+function isMobileEditor() {
+  return MOBILE_EDITOR_MQ.matches;
+}
+
+function updateEditorLayoutMode() {
   const shell = $('#studioShell');
-  if (meta) meta.classList.remove('is-collapsed');
-  if (shell && window.matchMedia('(max-width: 960px)').matches) {
-    shell.classList.add('is-mobile-nav-open');
+  if (!shell) return;
+  const rich = state.editorMode === 'rich' || isMobileEditor();
+  shell.classList.toggle('is-rich-mode', rich);
+  document.body.classList.toggle('is-mobile-editor', isMobileEditor());
+  refreshEditorLayout();
+}
+
+async function applyEditorViewport() {
+  updateEditorLayoutMode();
+  if (isMobileEditor() && state.editorMode !== 'rich') {
+    await switchEditorMode('rich');
   }
-  const field = $('#seriesField');
-  if (field) field.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-  $('#seriesInput')?.focus();
+}
+
+function switchNavTab(tab) {
+  document.querySelectorAll('.studio-nav-tab').forEach(btn => {
+    const active = btn.dataset.navTab === tab;
+    btn.classList.toggle('is-active', active);
+    btn.setAttribute('aria-selected', active ? 'true' : 'false');
+  });
+  document.querySelectorAll('.studio-nav-panel').forEach(panel => {
+    panel.classList.toggle('is-active', panel.dataset.navPanel === tab);
+  });
+}
+
+function openNavDrawer(tab = 'list') {
+  switchNavTab(tab);
+  const shell = $('#studioShell');
+  const backdrop = $('#studioDrawerBackdrop');
+  if (shell) shell.classList.add('is-mobile-nav-open');
+  if (backdrop) backdrop.hidden = false;
+}
+
+function closeNavDrawer() {
+  const shell = $('#studioShell');
+  const backdrop = $('#studioDrawerBackdrop');
+  if (shell) shell.classList.remove('is-mobile-nav-open');
+  if (backdrop) backdrop.hidden = true;
+}
+
+function openMetaSettings(section) {
+  switchNavTab('settings');
+  if (isMobileEditor()) openNavDrawer('settings');
+  if (section === 'series') $('#seriesInput')?.focus();
+  else if (section === 'tags') $('#tagInput')?.focus();
+}
+
+function syncDeleteButtons(show) {
+  const vis = show ? '' : 'none';
+  const del = $('#btnDelete');
+  const delM = $('#btnDeleteMobile');
+  if (del) del.style.display = vis;
+  if (delM) delM.style.display = vis;
+}
+
+function bindNavTabs() {
+  document.querySelectorAll('.studio-nav-tab').forEach(btn => {
+    btn.addEventListener('click', () => switchNavTab(btn.dataset.navTab));
+  });
+  $('#navCloseBtn')?.addEventListener('click', closeNavDrawer);
+  $('#studioDrawerBackdrop')?.addEventListener('click', closeNavDrawer);
+}
+
+function bindMobileTogglesSync() {
+  const pairs = [
+    ['draftToggle', 'draftToggleMobile'],
+    ['pinnedToggle', 'pinnedToggleMobile'],
+    ['carouselToggle', 'carouselToggleMobile'],
+  ];
+  pairs.forEach(([desktopId, mobileId]) => {
+    const d = $('#' + desktopId);
+    const m = $('#' + mobileId);
+    if (!d || !m) return;
+    const syncFromDesktop = () => { m.checked = d.checked; };
+    const syncFromMobile = () => { d.checked = m.checked; };
+    d.addEventListener('change', syncFromDesktop);
+    m.addEventListener('change', syncFromMobile);
+    syncFromDesktop();
+  });
+}
+
+function bindMobileChrome() {
+  $('#btnMobileList')?.addEventListener('click', () => openNavDrawer('list'));
+  $('#btnMobileSettings')?.addEventListener('click', () => openNavDrawer('settings'));
+  $('#btnPublishMobile')?.addEventListener('click', () => $('#btnPublish')?.click());
+  $('#btnDeleteMobile')?.addEventListener('click', () => $('#btnDelete')?.click());
+  $('#btnGenSummaryMeta')?.addEventListener('click', () => $('#btnGenSummary')?.click());
+  MOBILE_EDITOR_MQ.addEventListener('change', () => applyEditorViewport());
+}
+
+function focusSeriesPanel() {
+  openMetaSettings('series');
+}
+
+function focusTagPanel() {
+  openMetaSettings('tags');
 }
 
 function validateBeforePublish({ title, slug, content, tags, summary, allPosts, isUpdate }) {
@@ -725,6 +819,7 @@ async function publish() {
     showToast(draft ? '草稿已保存' : '发布成功，几十秒后线上生效');
     loadDocList();
     renderSummaryPreview();
+    closeNavDrawer();
 
     const newUrl = new URL(window.location.href);
     newUrl.searchParams.set('slug', slug);
@@ -1002,6 +1097,10 @@ async function setupVditor(initialMd) {
 
 async function switchEditorMode(target) {
   if (!target || target === state.editorMode) return;
+  if (target === 'markdown' && isMobileEditor()) {
+    showToast('移动端仅支持富文本编辑');
+    return;
+  }
   const buttons = document.querySelectorAll('.editor-mode-btn');
 
   if (target === 'rich') {
@@ -1037,7 +1136,6 @@ async function switchEditorMode(target) {
     state.editorMode = 'rich';
     const sourcePanel = document.querySelector('.studio-panel-source') || document.querySelector('.editor-pane');
     if (sourcePanel) sourcePanel.classList.add('is-rich');
-    refreshEditorLayout();
   } else {
     // 富文本 → Markdown：取 Vditor markdown 灌回 EasyMDE
     if (state.vditor && state.vditorReady) {
@@ -1051,7 +1149,6 @@ async function switchEditorMode(target) {
     if (sourcePanel) sourcePanel.classList.remove('is-rich');
     setStatus('已切换到 Markdown', 'saved');
     if (state.mde && state.mde.codemirror) state.mde.codemirror.refresh();
-    refreshEditorLayout();
   }
 
   buttons.forEach(b => {
@@ -1060,6 +1157,7 @@ async function switchEditorMode(target) {
     b.setAttribute('aria-selected', active ? 'true' : 'false');
   });
   updatePreview();
+  updateEditorLayoutMode();
 }
 
 function bindEditorModeSwitch() {
@@ -1138,35 +1236,12 @@ function bindEditorLayoutRefresh() {
   setTimeout(run, 800);
 }
 
-function bindMetaCollapse() {
-  const meta = $('#editorMeta');
-  const btn = $('#metaCollapseBtn');
-  if (!meta || !btn) return;
-
-  const key = 'editor_meta_collapsed';
-  const collapsed = localStorage.getItem(key) === '1';
-  meta.classList.toggle('is-collapsed', collapsed);
-  btn.textContent = collapsed ? '展开' : '收起';
-  btn.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
-
-  btn.addEventListener('click', () => {
-    const next = !meta.classList.contains('is-collapsed');
-    meta.classList.toggle('is-collapsed', next);
-    btn.textContent = next ? '展开' : '收起';
-    btn.setAttribute('aria-expanded', next ? 'false' : 'true');
-    localStorage.setItem(key, next ? '1' : '0');
-    refreshEditorLayout();
-  });
-}
-
 function bindStudioChrome() {
   const shell = $('#studioShell');
   const workspace = $('#studioWorkspace');
   const splitter = $('#studioSplitter');
   const navBtn = $('#navCollapseBtn');
   const outlineBtn = $('#outlineCollapseBtn');
-  const mobileNavBtn = $('#btnToggleNav');
-  const mobileOutlineBtn = $('#btnToggleOutline');
   const docSearch = $('#docSearch');
   const footAddTag = $('#footAddTag');
   const btnGenSummary = $('#btnGenSummary');
@@ -1189,19 +1264,6 @@ function bindStudioChrome() {
     if (localStorage.getItem('studio_outline_collapsed') === '1') shell.classList.add('is-outline-collapsed');
   }
 
-  if (mobileNavBtn && shell) {
-    mobileNavBtn.addEventListener('click', () => {
-      shell.classList.toggle('is-mobile-nav-open');
-      shell.classList.remove('is-mobile-outline-open');
-    });
-  }
-  if (mobileOutlineBtn && shell) {
-    mobileOutlineBtn.addEventListener('click', () => {
-      shell.classList.toggle('is-mobile-outline-open');
-      shell.classList.remove('is-mobile-nav-open');
-    });
-  }
-
   if (docSearch) {
     docSearch.addEventListener('input', () => {
       state.docSearch = docSearch.value;
@@ -1209,23 +1271,10 @@ function bindStudioChrome() {
     });
   }
 
-  if (footAddTag) {
-    footAddTag.addEventListener('click', () => {
-      const meta = $('#editorMeta');
-      if (meta) meta.classList.remove('is-collapsed');
-      const nav = $('#studioNav');
-      if (nav) nav.scrollTop = nav.scrollHeight;
-      $('#tagInput')?.focus();
-      if (window.matchMedia('(max-width: 960px)').matches && shell) {
-        shell.classList.add('is-mobile-nav-open');
-      }
-    });
-  }
+  if (footAddTag) footAddTag.addEventListener('click', focusTagPanel);
 
   const footAddSeries = $('#footAddSeries');
-  if (footAddSeries) {
-    footAddSeries.addEventListener('click', focusSeriesPanel);
-  }
+  if (footAddSeries) footAddSeries.addEventListener('click', focusSeriesPanel);
 
   if (btnGenSummary) {
     btnGenSummary.addEventListener('click', () => {
@@ -1371,8 +1420,10 @@ function setupEasyMDE() {
 
   setupEasyMDE();
   bindEditorLayoutRefresh();
-  bindMetaCollapse();
+  bindNavTabs();
   bindStudioChrome();
+  bindMobileChrome();
+  bindMobileTogglesSync();
   bindEditorModeSwitch();
   setupDragAndPaste();
   bindTagPicker();
@@ -1396,22 +1447,6 @@ function setupEasyMDE() {
 
   $('#btnPublish').addEventListener('click', publish);
   $('#btnDelete').addEventListener('click', deletePost);
-  $('#btnPreview').addEventListener('click', () => {
-    const shell = $('#studioShell');
-    if (shell) {
-      if (shell.classList.contains('is-preview-only')) {
-        shell.classList.remove('is-preview-only');
-        shell.classList.add('is-edit-only');
-      } else if (shell.classList.contains('is-edit-only')) {
-        shell.classList.remove('is-edit-only');
-      } else {
-        shell.classList.add('is-preview-only');
-      }
-      refreshEditorLayout();
-      return;
-    }
-    document.querySelectorAll('.editor-pane').forEach(el => el.classList.toggle('preview-mode'));
-  });
 
   // 自动草稿到 localStorage
   const draftKey = 'editor_draft_' + (initialSlug || 'new');
@@ -1459,4 +1494,5 @@ function setupEasyMDE() {
   } else {
     updatePreview();
   }
+  await applyEditorViewport();
 })();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

后台编辑页重构 + 滚动修复 + 专栏 + 本次三项体验优化。

## 本次更新

### 1. 文章信息 UI 重做
- 左栏改为 **「列表 | 设置」** 两个 Tab，不再挤在底部
- 设置页分区：**基础信息 / 专栏 / 标签 / 发布选项**
- 表单卡片化，字段网格排版，摘要区独立展示

### 2. 富文本单栏
- 切换到富文本时自动隐藏预览分栏、分隔条、右侧目录
- 编辑区占满中间区域，Vditor 所见即所得全宽显示

### 3. 移动端专用体验
- **仅支持富文本**（隐藏 Markdown 切换，进入页面自动加载 Vditor）
- 顶栏精简：返回 + 状态
- 底部固定操作栏：**文章 | 设置 | 发布**
- 设置/列表以侧滑抽屉呈现，带遮罩层
- 草稿/置顶/轮播/删除移至设置页

## 其他能力（同分支）
- 专栏（series）编辑、Markdown 滚动修复、编辑预览分栏与目录 TOC
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53890161-a286-43a2-9d7b-d41551c87404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53890161-a286-43a2-9d7b-d41551c87404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

