### PR TITLE
chore(cloudbase): add secrets.env deploy flow for SMTP reply notify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ node_modules/
 .idea/
 .vscode/
 .env
+cloudbase/secrets.env
+cloudbase/.cloudbaserc.deploy.json
 
 # 诊断时残留的写入测试文件
 .diagnose-*

--- a/cloudbase/README.md
+++ b/cloudbase/README.md
@@ -145,9 +145,39 @@ embedBaseUrl: 'https://gitbolg-d7gmnsrw46e011706-1256429518.tcloudbaseapp.com',
 
 ### 回复邮件通知（可选）
 
-当被回复的评论**留有邮箱**时，云函数会异步发送通知邮件。默认关闭，配置 SMTP 后设 `REPLY_NOTIFY_ENABLED=1` 即可。
+当被回复的评论**留有邮箱**时，云函数会异步发送通知邮件。
 
-QQ 邮箱示例：在 QQ 邮箱设置中开启 SMTP，使用授权码作为 `SMTP_PASS`。
+#### 方式 A：自动部署（推荐，授权码不进 Git）
+
+1. 在 QQ 邮箱 → 设置 → 账户 → 开启 **SMTP** → 生成 **授权码**
+2. 在 `cloudbase/` 目录：
+
+```bash
+cp secrets.env.example secrets.env
+# 编辑 secrets.env，把 SMTP_PASS 改成你的授权码
+node deploy-comments-fn.mjs -e gitbolg-d7gmnsrw46e011706
+```
+
+`secrets.env` 已加入 `.gitignore`，部署脚本会临时注入环境变量，**部署后自动从 cloudbaserc.json 清除授权码**。
+
+当前默认发件邮箱：`237199972@qq.com`（可在 `secrets.env` 修改）。
+
+#### 方式 B：控制台手动配置
+
+云函数 `gitblog-comments` → 环境变量：
+
+| 变量 | 值 |
+|------|-----|
+| `REPLY_NOTIFY_ENABLED` | `1` |
+| `SMTP_HOST` | `smtp.qq.com` |
+| `SMTP_PORT` | `465` |
+| `SMTP_USER` | `237199972@qq.com` |
+| `SMTP_PASS` | QQ 邮箱授权码 |
+| `SMTP_FROM` | `237199972@qq.com` |
+
+保存后重新部署云函数。
+
+> 授权码只填在 `secrets.env` 或控制台，**不要**提交到 Git 仓库。
 
 ## 8. 前端配置
 

--- a/cloudbase/cloudbaserc.json
+++ b/cloudbase/cloudbaserc.json
@@ -17,12 +17,12 @@
         "COMMENT_MODERATION": "0",
         "COMMENT_SALT": "change-me-in-console",
         "ALLOWED_ORIGINS": "https://gitpull.cn,https://www.gitpull.cn",
-        "REPLY_NOTIFY_ENABLED": "0",
-        "SMTP_HOST": "",
+        "REPLY_NOTIFY_ENABLED": "1",
+        "SMTP_HOST": "smtp.qq.com",
         "SMTP_PORT": "465",
-        "SMTP_USER": "",
+        "SMTP_USER": "237199972@qq.com",
         "SMTP_PASS": "",
-        "SMTP_FROM": ""
+        "SMTP_FROM": "237199972@qq.com"
       }
     }
   ]

--- a/cloudbase/deploy-comments-fn.mjs
+++ b/cloudbase/deploy-comments-fn.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * 从 secrets.env 读取 SMTP 授权码，临时合并进 cloudbaserc 后部署云函数，
+ * 部署完成后自动清除 cloudbaserc 中的 SMTP_PASS（避免误提交 Git）。
+ *
+ * 用法（在 cloudbase/ 目录）：
+ *   node deploy-comments-fn.mjs
+ *   node deploy-comments-fn.mjs -e gitbolg-d7gmnsrw46e011706
+ */
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dir = path.dirname(fileURLToPath(import.meta.url));
+const rcPath = path.join(__dir, 'cloudbaserc.json');
+const secretsPath = path.join(__dir, 'secrets.env');
+
+function parseEnvFile(content) {
+  const out = {};
+  for (const line of content.split('\n')) {
+    const t = line.trim();
+    if (!t || t.startsWith('#')) continue;
+    const i = t.indexOf('=');
+    if (i === -1) continue;
+    const key = t.slice(0, i).trim();
+    const val = t.slice(i + 1).trim();
+    if (key) out[key] = val;
+  }
+  return out;
+}
+
+function mergeEnv(rc, secrets) {
+  const fn = rc.functions?.find(f => f.name === 'gitblog-comments');
+  if (!fn) throw new Error('cloudbaserc.json 中未找到 gitblog-comments');
+  fn.envVariables = { ...fn.envVariables, ...secrets };
+  return fn;
+}
+
+const envArg = process.argv.find((a, i) => process.argv[i - 1] === '-e');
+const original = fs.readFileSync(rcPath, 'utf8');
+const rc = JSON.parse(original);
+
+if (!fs.existsSync(secretsPath)) {
+  console.error('缺少 cloudbase/secrets.env');
+  console.error('请执行：cp secrets.env.example secrets.env');
+  console.error('然后编辑 secrets.env，填入 SMTP_PASS（QQ 邮箱授权码）');
+  process.exit(1);
+}
+
+const secrets = parseEnvFile(fs.readFileSync(secretsPath, 'utf8'));
+if (!secrets.SMTP_PASS || secrets.SMTP_PASS.includes('你的')) {
+  console.error('请在 secrets.env 中填写真实的 SMTP_PASS（QQ 邮箱 SMTP 授权码）');
+  process.exit(1);
+}
+
+const fn = mergeEnv(rc, secrets);
+const envId = envArg || rc.envId;
+if (!envId) {
+  console.error('请指定环境 ID：node deploy-comments-fn.mjs -e <envId>');
+  process.exit(1);
+}
+
+fs.writeFileSync(rcPath, `${JSON.stringify(rc, null, 2)}\n`);
+console.log(`部署 gitblog-comments → ${envId}（已合并 secrets.env，含 SMTP 配置）`);
+
+try {
+  execSync(`tcb fn deploy gitblog-comments -e ${envId}`, {
+    cwd: __dir,
+    stdio: 'inherit',
+  });
+  console.log('\n部署成功。回复邮件通知已启用（被回复者须填写邮箱）。');
+} catch (err) {
+  console.error('\n部署失败，请确认已安装并登录 CloudBase CLI：npm i -g @cloudbase/cli && tcb login');
+  process.exit(err.status || 1);
+} finally {
+  const restored = JSON.parse(original);
+  fs.writeFileSync(rcPath, `${JSON.stringify(restored, null, 2)}\n`);
+  console.log('已恢复 cloudbaserc.json（SMTP_PASS 未保留在仓库文件中）。');
+}

--- a/cloudbase/secrets.env.example
+++ b/cloudbase/secrets.env.example
@@ -1,0 +1,9 @@
+# 复制为 secrets.env 并填写 SMTP_PASS（QQ 邮箱授权码，不是 QQ 密码）
+# cp secrets.env.example secrets.env
+
+REPLY_NOTIFY_ENABLED=1
+SMTP_HOST=smtp.qq.com
+SMTP_PORT=465
+SMTP_USER=237199972@qq.com
+SMTP_PASS=你的QQ邮箱授权码
+SMTP_FROM=237199972@qq.com

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "strip:wechat": "node scripts/strip-wechat.mjs",
     "release": "node scripts/make-release.mjs",
     "release:push": "node scripts/make-release.mjs --push",
-    "tools:pages": "node scripts/generate-tool-pages.mjs"
+    "tools:pages": "node scripts/generate-tool-pages.mjs",
+    "cloudbase:deploy-comments": "node cloudbase/deploy-comments-fn.mjs -e gitbolg-d7gmnsrw46e011706"
   },
   "devDependencies": {
     "cheerio": "^1.0.0",


### PR DESCRIPTION
- Prefill QQ mail 237199972@qq.com in cloudbaserc (no auth code in git)
- Add secrets.env.example and deploy-comments-fn.mjs for safe deploy
- Gitignore secrets.env; restore cloudbaserc after deploy