### PR TITLE
fix(comments): use permanent storage URLs for comment images

### DIFF
--- a/cloudbase/README.md
+++ b/cloudbase/README.md
@@ -147,6 +147,8 @@ node deploy-static-embed.mjs
 
 控制台 → 云存储 → 权限：允许**所有用户可读**，**仅云函数可写**。
 
+评论图片使用永久公开地址 `https://{envId}.tcb.qcloud.la/comments/...`（不再使用会过期的临时签名链）。若图片 403，请检查云存储是否为公开读；自定义 CDN 域名可设置环境变量 `STORAGE_PUBLIC_BASE`（不含末尾 `/`）。
+
 ## 7. 云函数环境变量
 
 | 变量 | 说明 |
@@ -154,6 +156,7 @@ node deploy-static-embed.mjs
 | `COMMENT_MODERATION` | `1` 开启审核，`0` 直接显示 |
 | `COMMENT_SALT` | 随机字符串，用于 IP hash |
 | `ALLOWED_ORIGINS` | HTTP 模式跨域来源（embed 模式可忽略） |
+| `STORAGE_PUBLIC_BASE` | 云存储公开访问根 URL（可选，如 `https://{envId}.tcb.qcloud.la`） |
 | `REPLY_NOTIFY_ENABLED` | `1` 开启回复邮件通知（须配置 SMTP） |
 | `SMTP_HOST` | SMTP 服务器，如 `smtp.qq.com` |
 | `SMTP_PORT` | 端口，SSL 通常 `465`，TLS 用 `587` |

--- a/cloudbase/functions/gitblog-comments/index.js
+++ b/cloudbase/functions/gitblog-comments/index.js
@@ -31,6 +31,51 @@ function hashIp(ip) {
   return crypto.createHash('sha256').update(String(ip || '') + (process.env.COMMENT_SALT || 'gitblog')).digest('hex').slice(0, 24);
 }
 
+function parseCloudPathFromFileId(fileId) {
+  const m = String(fileId || '').match(/^cloud:\/\/[^/]+\/(.+)$/);
+  return m ? decodeURIComponent(m[1]) : '';
+}
+
+function getEnvIdFromFileId(fileId) {
+  const m = String(fileId || '').match(/^cloud:\/\/([^/.]+)/);
+  return m ? m[1] : '';
+}
+
+/** 云存储公开读时的永久 HTTPS 地址（避免 getTempFileURL 临时链过期 403） */
+function getStoragePublicUrl(cloudPath, fileId = '') {
+  const path = String(cloudPath || parseCloudPathFromFileId(fileId)).replace(/^\/+/, '');
+  if (!path) return '';
+  const customBase = String(process.env.STORAGE_PUBLIC_BASE || '').trim().replace(/\/+$/, '');
+  if (customBase) return `${customBase}/${path}`;
+  const envId = String(process.env.TCB_ENV || process.env.SCF_NAMESPACE || getEnvIdFromFileId(fileId)).trim();
+  if (!envId) return '';
+  return `https://${envId}.tcb.qcloud.la/${path}`;
+}
+
+function resolveCommentImageSrc(src) {
+  const raw = String(src || '').trim();
+  if (!raw) return raw;
+  if (raw.startsWith('cloud://')) {
+    return getStoragePublicUrl('', raw) || raw;
+  }
+  try {
+    const u = new URL(raw);
+    if (/\.tcb\.qcloud\.la$/i.test(u.hostname) && u.pathname.includes('/comments/')) {
+      const cloudPath = u.pathname.replace(/^\//, '');
+      const publicUrl = getStoragePublicUrl(cloudPath);
+      if (publicUrl) return publicUrl;
+    }
+  } catch { /* ignore */ }
+  return raw;
+}
+
+function resolveCommentImageUrls(html) {
+  return String(html || '').replace(
+    /(<img\b[^>]*\ssrc=)(["'])([^"']+)\2/gi,
+    (full, prefix, quote, src) => `${prefix}${quote}${resolveCommentImageSrc(src).replace(/"/g, '&quot;')}${quote}`,
+  );
+}
+
 function stripPlain(html) {
   return String(html || '').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
 }
@@ -158,7 +203,7 @@ function publicComment(row) {
     _id: row._id,
     path: row.path,
     nick: row.nick || '访客',
-    contentHtml: stripMentionHtml(row.contentHtml),
+    contentHtml: resolveCommentImageUrls(stripMentionHtml(row.contentHtml)),
     parentId: row.parentId || null,
     replyToNick: row.replyToNick || null,
     createdAt: row.createdAt,
@@ -244,7 +289,7 @@ async function handleGet(event) {
 
 async function handlePost(event, context) {
   const path = String(event.path || '').trim();
-  let contentHtml = sanitizeHtml(event.contentHtml);
+  let contentHtml = resolveCommentImageUrls(sanitizeHtml(event.contentHtml));
   const plain = stripPlain(contentHtml);
   if (!path) return jsonErr('缺少 path');
   if (!plain) return jsonErr('评论内容不能为空');
@@ -327,11 +372,7 @@ async function handleUpload(event, context) {
     fileContent: buf,
   });
   const fileId = uploadRes.fileID;
-  let url = fileId;
-  try {
-    const temp = await app.getTempFileURL({ fileList: [fileId] });
-    url = temp?.fileList?.[0]?.tempFileURL || fileId;
-  } catch (_) { /* use fileID */ }
+  const url = getStoragePublicUrl(cloudPath, fileId) || fileId;
 
   return jsonOk({ url, fileId });
 }


### PR DESCRIPTION
Temp getTempFileURL links expire and return 403. Serve public tcb.qcloud.la URLs on upload and resolve legacy signed URLs when loading comments.